### PR TITLE
Feature/25 apps chat list ticketed inbox escalations only

### DIFF
--- a/app/app/(tabs)/home.tsx
+++ b/app/app/(tabs)/home.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import Feathericons from "@expo/vector-icons/Feather";
 import { useRouter } from "expo-router";
 import { useAuth } from "@/contexts/AuthContext";
-import { checkDatabaseHealth } from "@/database/utils";
 import typography from "@/styles/typography";
 import themeColors from "@/styles/colors";
 import ParallaxScrollView from "@/components/parallax-scroll-view";
@@ -13,22 +12,6 @@ import Avatar from "@/components/avatar";
 export default function HomeScreen() {
   const router = useRouter();
   const { logout, user } = useAuth();
-  const [isDatabaseHealthy, setIsDatabaseHealthy] = useState(true);
-
-  useEffect(() => {
-    // Check database health on mount
-    const checkHealth = () => {
-      const isHealthy = checkDatabaseHealth();
-      setIsDatabaseHealthy(isHealthy);
-    };
-
-    checkHealth();
-
-    // Check database health periodically (every 5 seconds)
-    const healthCheckInterval = setInterval(checkHealth, 5000);
-
-    return () => clearInterval(healthCheckInterval);
-  }, []);
 
   const handleLogout = async () => {
     try {
@@ -74,19 +57,11 @@ export default function HomeScreen() {
           </View>
         </View>
         <TouchableOpacity
-          style={[
-            styles.logoutButton,
-            !isDatabaseHealthy && styles.logoutButtonDisabled,
-          ]}
+          style={[styles.logoutButton]}
           onPress={handleLogout}
-          disabled={!isDatabaseHealthy}
           test-id="logout-button"
         >
-          <Feathericons
-            name="log-out"
-            size={24}
-            color={isDatabaseHealthy ? "#fff" : "#999"}
-          />
+          <Feathericons name="log-out" size={24} color={"white"} />
         </TouchableOpacity>
       </View>
 
@@ -405,9 +380,6 @@ const styles = StyleSheet.create({
   },
   logoutButton: {
     padding: 8,
-  },
-  logoutButtonDisabled: {
-    opacity: 0.5,
   },
   profileDetails: {
     lineHeight: 28,

--- a/app/app/(tabs)/home.tsx
+++ b/app/app/(tabs)/home.tsx
@@ -31,11 +31,6 @@ export default function HomeScreen() {
   }, []);
 
   const handleLogout = async () => {
-    if (!isDatabaseHealthy) {
-      console.warn("Database not healthy, logout disabled");
-      return;
-    }
-
     try {
       await logout();
       router.replace("/login");

--- a/app/app/(tabs)/inbox.tsx
+++ b/app/app/(tabs)/inbox.tsx
@@ -1,13 +1,235 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useMemo, useState, useCallback, useEffect } from "react";
+import {
+  StyleSheet,
+  Text,
+  View,
+  FlatList,
+  ActivityIndicator,
+} from "react-native";
+import { useRouter } from "expo-router";
 import themeColors from "@/styles/colors";
+import typography from "@/styles/typography";
+import InboxTabs from "@/components/inbox/tabs-button";
+import Search from "@/components/inbox/search";
+import TicketItem, {
+  Ticket as TicketType,
+} from "@/components/inbox/ticket-item";
+import { useAuth } from "@/contexts/AuthContext";
+import { api } from "@/services/api";
+
+type Ticket = TicketType;
+
+const Tabs = {
+  PENDING: "open",
+  RESPONDED: "resolved",
+} as const;
 
 const Inbox: React.FC = () => {
+  const router = useRouter();
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [activeTab, setActiveTab] = useState<(typeof Tabs)[keyof typeof Tabs]>(
+    Tabs.PENDING
+  );
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const pageSize = 10; // default page size to request
+  const endReachedTimeout = React.useRef<number | null>(null);
+  const isFetchingRef = React.useRef(false); // prevent duplicate fetches
+  const isInitialMount = React.useRef(true); // track initial mount
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return tickets.filter((t: Ticket) => {
+      const isResolved = !!t.resolved_at;
+      if (activeTab === Tabs.PENDING && isResolved) return false;
+      if (activeTab === Tabs.RESPONDED && !isResolved) return false;
+
+      if (!q) return true;
+      const inName = t.customer.name.toLowerCase().includes(q);
+      const inContent = (t.message?.body || "").toLowerCase().includes(q);
+      const inTicketId = t.ticket_number.toLowerCase().includes(q);
+      return inName || inContent || inTicketId;
+    });
+  }, [tickets, activeTab, query]);
+  const { user } = useAuth();
+
+  const onPressTicket = (ticket: Ticket) => {
+    // Navigate to the chat screen, passing ticket_number as query param
+    router.push(
+      `/chat?ticketNumber=${encodeURIComponent(ticket.ticket_number)}`
+    );
+  };
+
+  const fetchTickets = useCallback(
+    async (
+      tab: (typeof Tabs)[keyof typeof Tabs],
+      p: number,
+      append: boolean = false,
+      isRefreshing: boolean = false
+    ) => {
+      // Prevent concurrent fetches
+      if (isFetchingRef.current) return;
+
+      if (!user?.accessToken) return;
+
+      isFetchingRef.current = true;
+
+      try {
+        setError(null);
+        if (isRefreshing) setRefreshing(true);
+        else setLoading(true);
+
+        const apiData = await api.getTickets(
+          user.accessToken,
+          tab,
+          p,
+          pageSize
+        );
+        // API response shape: { tickets, total, page, size }
+        const fetched: Ticket[] = apiData?.tickets || [];
+        const total: number | undefined = apiData?.total;
+        const size: number | undefined = apiData?.size || pageSize;
+        const currentPage: number | undefined = apiData?.page || p;
+
+        // if API provides total/size, compute hasMore using pages
+        if (typeof total === "number" && typeof size === "number") {
+          const totalPages = Math.ceil(total / size);
+          setHasMore((currentPage ?? p) < totalPages);
+        } else {
+          setHasMore(fetched.length > 0);
+        }
+
+        setTickets((prev: Ticket[]) =>
+          append ? [...prev, ...fetched] : fetched
+        );
+      } catch (error) {
+        console.error("Failed to fetch tickets:", error);
+        setError((error as Error)?.message || "Failed to fetch tickets");
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+        isFetchingRef.current = false;
+      }
+    },
+    [user?.accessToken, pageSize]
+  );
+
+  // Reset list when tab changes
+  useEffect(() => {
+    // On initial mount, just fetch - don't reset
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      fetchTickets(activeTab, 1, false);
+      return;
+    }
+
+    // On subsequent tab changes, reset everything
+    setPage(1);
+    setTickets([]);
+    setHasMore(true);
+    setError(null);
+    // Fetch first page for new tab
+    fetchTickets(activeTab, 1, false);
+  }, [activeTab, fetchTickets]);
+
+  // Fetch when page changes (but not on initial mount or tab change)
+  useEffect(() => {
+    // Skip if page is 1 (already handled by tab change effect)
+    if (page === 1) return;
+    // Skip if refreshing
+    if (refreshing) return;
+
+    fetchTickets(activeTab, page, true);
+  }, [page, activeTab, fetchTickets, refreshing]);
+
+  const renderEmpty = () => (
+    <View style={styles.emptyContainer}>
+      {error ? (
+        <View style={{ alignItems: "center" }}>
+          <Text style={[typography.body3, { color: themeColors.error }]}>
+            {" "}
+            {error}
+          </Text>
+          <Text
+            onPress={() => {
+              // retry
+              setPage(1);
+              setTickets([]);
+              setHasMore(true);
+              fetchTickets(activeTab, 1, false);
+            }}
+            style={[
+              typography.body3,
+              { color: themeColors.dark1, marginTop: 8 },
+            ]}
+          >
+            Retry
+          </Text>
+        </View>
+      ) : (
+        <Text style={[typography.body3, { color: themeColors.dark3 }]}>
+          No tickets available
+        </Text>
+      )}
+    </View>
+  );
+
   return (
     <View style={styles.container}>
-      <View style={styles.content}>
-        <Text style={styles.title}>Inbox Page</Text>
+      {/* Tabs */}
+      <View style={styles.tabsContainer}>
+        <InboxTabs
+          activeTab={activeTab}
+          onChange={(t: string) => setActiveTab(t as any)}
+        />
       </View>
+
+      {/* Search */}
+      <Search value={query} onChange={setQuery} />
+
+      {/* List */}
+      <FlatList<Ticket>
+        data={filtered}
+        keyExtractor={(item: Ticket) => String(item.id)}
+        renderItem={({ item }: { item: Ticket }) => (
+          <TicketItem ticket={item} onPress={onPressTicket} />
+        )}
+        ListEmptyComponent={renderEmpty}
+        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        onEndReachedThreshold={0.5}
+        onEndReached={() => {
+          // debounce rapid calls
+          if (loading || !hasMore) return;
+          if (endReachedTimeout.current) {
+            window.clearTimeout(endReachedTimeout.current);
+          }
+          // schedule page increment after 200ms; if another call comes in the window it'll reset
+          endReachedTimeout.current = window.setTimeout(() => {
+            setPage((prev: number) => prev + 1);
+            endReachedTimeout.current = null;
+          }, 200);
+        }}
+        refreshing={refreshing}
+        onRefresh={() => {
+          // pull-to-refresh: reset to first page and fetch
+          setPage(1);
+          setTickets([]);
+          setHasMore(true);
+          setError(null);
+          fetchTickets(activeTab, 1, false, true);
+        }}
+        ListFooterComponent={() =>
+          loading ? (
+            <View style={styles.footer}>
+              <ActivityIndicator size="small" color={themeColors.dark3} />
+            </View>
+          ) : null
+        }
+      />
     </View>
   );
 };
@@ -17,14 +239,18 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: themeColors.background,
   },
-  content: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
+  tabsContainer: {
+    padding: 16,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: "bold",
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingVertical: 32,
+  },
+  footer: {
+    paddingVertical: 16,
+    alignItems: "center",
   },
 });
 

--- a/app/app/(tabs)/inbox.tsx
+++ b/app/app/(tabs)/inbox.tsx
@@ -50,10 +50,16 @@ const Inbox: React.FC = () => {
     return tickets
       .filter((t: Ticket) => {
         const isResolved = !!t.resolvedAt;
-        if (activeTab === Tabs.PENDING && isResolved) return false;
-        if (activeTab === Tabs.RESPONDED && !isResolved) return false;
+        if (activeTab === Tabs.PENDING && isResolved) {
+          return false;
+        }
+        if (activeTab === Tabs.RESPONDED && !isResolved) {
+          return false;
+        }
 
-        if (!q) return true;
+        if (!q) {
+          return true;
+        }
         const inName = t.customer?.name.toString().includes(q);
         const inContent = (t.message?.body.toString() || "").includes(q);
         const inTicketId = t.ticketNumber.toLowerCase().includes(q);
@@ -79,7 +85,7 @@ const Inbox: React.FC = () => {
   const onPressTicket = (ticket: Ticket) => {
     // update unreadCount
     if (ticket.unreadCount && ticket.unreadCount > 0) {
-      const _unreadCount = ticket.unreadCount - 1;
+      const _unreadCount = 0;
       const updated = {
         ...ticket,
         unreadCount: _unreadCount,
@@ -104,16 +110,23 @@ const Inbox: React.FC = () => {
       isRefreshing: boolean = false,
     ) => {
       // Prevent concurrent fetches
-      if (isFetchingRef.current) return;
+      if (isFetchingRef.current) {
+        return;
+      }
 
-      if (!user?.accessToken) return;
+      if (!user?.accessToken) {
+        return;
+      }
 
       isFetchingRef.current = true;
 
       try {
         setError(null);
-        if (isRefreshing) setRefreshing(true);
-        else setLoading(true);
+        if (isRefreshing) {
+          setRefreshing(true);
+        } else {
+          setLoading(true);
+        }
 
         // Use TicketSyncService to fetch tickets (local-first approach)
         const syncResult = await TicketSyncService.getTickets(
@@ -170,11 +183,17 @@ const Inbox: React.FC = () => {
   // Fetch when page changes (but not on initial mount or tab change)
   useEffect(() => {
     // Skip if page is 1 (already handled by tab change effect)
-    if (page === 1) return;
+    if (page === 1) {
+      return;
+    }
     // Skip if refreshing
-    if (refreshing) return;
+    if (refreshing) {
+      return;
+    }
     // Skip if there's an error
-    if (error) return;
+    if (error) {
+      return;
+    }
 
     fetchTickets(activeTab, page, true);
   }, [page, activeTab, fetchTickets, refreshing, error]);
@@ -236,7 +255,9 @@ const Inbox: React.FC = () => {
         onEndReachedThreshold={0.5}
         onEndReached={() => {
           // debounce rapid calls
-          if (loading || !hasMore) return;
+          if (loading || !hasMore) {
+            return;
+          }
           if (endReachedTimeout.current) {
             window.clearTimeout(endReachedTimeout.current);
           }

--- a/app/app/(tabs)/inbox.tsx
+++ b/app/app/(tabs)/inbox.tsx
@@ -44,17 +44,27 @@ const Inbox: React.FC = () => {
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return tickets.filter((t: Ticket) => {
-      const isResolved = !!t.resolvedAt;
-      if (activeTab === Tabs.PENDING && isResolved) return false;
-      if (activeTab === Tabs.RESPONDED && !isResolved) return false;
+    return tickets
+      .filter((t: Ticket) => {
+        const isResolved = !!t.resolvedAt;
+        if (activeTab === Tabs.PENDING && isResolved) return false;
+        if (activeTab === Tabs.RESPONDED && !isResolved) return false;
 
-      if (!q) return true;
-      const inName = t.customer?.name.toString().includes(q);
-      const inContent = (t.message?.body.toString() || "").includes(q);
-      const inTicketId = t.ticketNumber.toLowerCase().includes(q);
-      return inName || inContent || inTicketId;
-    });
+        if (!q) return true;
+        const inName = t.customer?.name.toString().includes(q);
+        const inContent = (t.message?.body.toString() || "").includes(q);
+        const inTicketId = t.ticketNumber.toLowerCase().includes(q);
+        return inName || inContent || inTicketId;
+      })
+      .sort((a: Ticket, b: Ticket) => {
+        // Sort by unreadCount desc, then createdAt desc
+        if ((b.unreadCount || 0) !== (a.unreadCount || 0)) {
+          return (b.unreadCount || 0) - (a.unreadCount || 0);
+        }
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      });
   }, [tickets, activeTab, query]);
   const { user } = useAuth();
 

--- a/app/app/(tabs)/inbox.tsx
+++ b/app/app/(tabs)/inbox.tsx
@@ -7,7 +7,7 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { useRouter, useLocalSearchParams } from "expo-router";
-import { useSQLiteContext } from "expo-sqlite";
+import { useDatabase } from "@/database/context";
 import themeColors from "@/styles/colors";
 import typography from "@/styles/typography";
 import InboxTabs from "@/components/inbox/tabs-button";
@@ -42,7 +42,7 @@ const Inbox: React.FC = () => {
   const endReachedTimeout = React.useRef<number | null>(null);
   const isFetchingRef = React.useRef(false); // prevent duplicate fetches
   const isInitialMount = React.useRef(true); // track initial mount
-  const db = useSQLiteContext();
+  const db = useDatabase();
   const { updateTicket } = useTicket();
 
   const filtered = useMemo(() => {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from "expo-router";
 import { SQLiteProvider, defaultDatabaseDirectory } from "expo-sqlite";
 import { DATABASE_NAME } from "@/database/config";
 import { migrateDbIfNeeded } from "@/database";
+import { TicketProvider } from "@/contexts/TicketContext";
 
 export const unstable_settings = {
   anchor: "(tabs)/inbox",
@@ -16,10 +17,12 @@ export default function RootLayout() {
       onInit={migrateDbIfNeeded}
     >
       <AuthProvider>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="login" options={{ headerShown: false }} />
-        </Stack>
+        <TicketProvider>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="login" options={{ headerShown: false }} />
+          </Stack>
+        </TicketProvider>
       </AuthProvider>
     </SQLiteProvider>
   );

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,9 +1,11 @@
+import React from "react";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { Stack } from "expo-router";
 import { SQLiteProvider, defaultDatabaseDirectory } from "expo-sqlite";
 import { DATABASE_NAME } from "@/database/config";
 import { migrateDbIfNeeded } from "@/database";
 import { TicketProvider } from "@/contexts/TicketContext";
+import HeaderOptions from "@/components/chat/header-options";
 
 export const unstable_settings = {
   anchor: "(tabs)/inbox",
@@ -21,6 +23,22 @@ export default function RootLayout() {
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
             <Stack.Screen name="login" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="chat"
+              options={({
+                navigation,
+                route,
+              }: {
+                navigation: any;
+                route: any;
+              }) => ({
+                headerShown: true,
+                headerTitleAlign: "left",
+                headerRight: () => (
+                  <HeaderOptions ticketID={route?.params?.ticketNumber} />
+                ),
+              })}
+            />
           </Stack>
         </TicketProvider>
       </AuthProvider>

--- a/app/app/chat.tsx
+++ b/app/app/chat.tsx
@@ -100,7 +100,7 @@ const ChatScreen = () => {
                 viewPosition: 1,
                 animated,
               });
-            } catch (error) {
+            } catch {
               // Fallback: scroll to end of list
               console.warn("ScrollToLocation failed, using fallback");
               listRef.current?.scrollToEnd({ animated });
@@ -171,7 +171,7 @@ const ChatScreen = () => {
                       viewPosition: 1,
                       animated: true,
                     });
-                  } catch (error) {
+                  } catch {
                     // Final fallback: scroll to end
                     listRef.current?.scrollToEnd({ animated: true });
                   }

--- a/app/app/chat.tsx
+++ b/app/app/chat.tsx
@@ -1,0 +1,402 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import {
+  Text,
+  KeyboardAvoidingView,
+  View,
+  Platform,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  SectionList,
+  ScrollView,
+} from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+import Feathericons from "@expo/vector-icons/Feather";
+import {
+  useChatPagination,
+  ChatPaginationProvider,
+} from "@/contexts/ChatPaginationContext";
+import MessageBubble from "@/components/chat/message-bubble";
+import typography from "@/styles/typography";
+import themeColors from "@/styles/colors";
+import chatUtils, { Message } from "@/utils/chat";
+import { formatDateLabel } from "@/utils/time";
+
+const dummyMessages = chatUtils.generateDummyMessages(10);
+
+const dummyAISuggestion =
+  "Effective crop management is essential for maximizing yield and ensuring sustainability. It involves planning, monitoring, and controlling various agricultural practices. Key components include soil health assessment, pest and weed control, and efficient water usage. By utilizing precision agriculture techniques, farmers can optimize inputs and enhance productivity while minimizing environmental impact.";
+
+const ChatScreen = () => {
+  const { ticketNumber } = useLocalSearchParams<{
+    ticketNumber?: string;
+  }>();
+  const [messages, setMessages] = useState<Message[]>(dummyMessages);
+  // how many message items (not counting date separators) are visible
+  const [visibleMessageCount, setVisibleMessageCount] = useState<number>(2);
+  // when > 0 we show the last `visibleDayCount` full day groups (date separators
+  // + all messages for that day). When 0 we use visibleMessageCount to show the
+  // last N messages only.
+  const [visibleDayCount, setVisibleDayCount] = useState<number>(0);
+  const [refreshing, setRefreshing] = useState<boolean>(false);
+  const [aiSuggestions, setAiSuggestions] = useState<string>(dummyAISuggestion);
+  const [text, setText] = useState<string>("");
+  const listRef = useRef<any | null>(null);
+
+  // compute which sections to display based on pagination state
+  const displayedSections = React.useMemo(() => {
+    const groups = chatUtils.groupMessagesByDate(messages); // [{date, items}]
+    if (groups.length === 0) return [];
+
+    if (visibleDayCount > 0) {
+      // if visibleDayCount covers all groups, return everything
+      if (visibleDayCount >= groups.length) {
+        return groups.map((g) => ({
+          title: formatDateLabel(g.date),
+          data: g.items,
+        }));
+      }
+      const chosen = groups.slice(-visibleDayCount);
+      const sections = chosen.map((g) => ({
+        title: formatDateLabel(g.date),
+        data: g.items,
+      }));
+      // mark the first section (oldest visible) if there are more groups available
+      if (groups.length > chosen.length && sections.length > 0) {
+        // attach a flag to indicate load earlier should show
+        (sections[0] as any).showLoadEarlier = true;
+      }
+      return sections;
+    }
+
+    // when not paginating by day, show only the last group's last N messages
+    const last = groups[groups.length - 1];
+    const items = last.items.slice(-visibleMessageCount);
+    const sections = [{ title: formatDateLabel(last.date), data: items }];
+    if (groups.length > 1) {
+      (sections[0] as any).showLoadEarlier = true;
+    }
+    return sections;
+  }, [messages, visibleDayCount, visibleMessageCount]);
+
+  const scrollToBottom = useCallback(
+    (animated = false) => {
+      // Use requestAnimationFrame to ensure the SectionList has rendered
+      requestAnimationFrame(() => {
+        setTimeout(
+          () => {
+            const sections = displayedSections;
+            if (!sections || sections.length === 0) return;
+
+            const sectionIndex = sections.length - 1;
+            const lastSection = sections[sectionIndex];
+            const itemIndex = Math.max(0, (lastSection.data?.length || 1) - 1);
+
+            try {
+              listRef.current?.scrollToLocation({
+                sectionIndex,
+                itemIndex,
+                viewPosition: 1,
+                animated,
+              });
+            } catch (error) {
+              // Fallback: scroll to end of list
+              console.warn("ScrollToLocation failed, using fallback");
+              listRef.current?.scrollToEnd({ animated });
+            }
+          },
+          animated ? 100 : 50,
+        );
+      });
+    },
+    [displayedSections],
+  );
+
+  // use context-based pagination store (in-memory) instead of AsyncStorage
+  const { getVisibleDayCount, setVisibleDayCountFor } = useChatPagination();
+
+  // sync initial visibleDayCount from context for this ticket
+  useEffect(() => {
+    const v = getVisibleDayCount(ticketNumber as string | undefined);
+    if (v && v > 0) setVisibleDayCount(v);
+  }, [getVisibleDayCount, ticketNumber]);
+  useEffect(() => {
+    // scroll to bottom on mount and when displayedSections change
+    scrollToBottom();
+  }, [scrollToBottom, displayedSections]);
+  // Sample messages for demonstration
+  // In a real app, fetch messages from an API or database
+
+  return (
+    <SafeAreaView style={styles.container} edges={["left", "right", "bottom"]}>
+      <View style={styles.header}>
+        <Text style={[typography.body3, { color: themeColors.dark5 }]}>
+          Ticket: {ticketNumber}
+        </Text>
+      </View>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 100 : 0}
+      >
+        <View style={styles.messagesContainer}>
+          <SectionList
+            ref={(r: any) => (listRef.current = r)}
+            sections={displayedSections}
+            keyExtractor={(item: Message) => `${item.id}`}
+            renderItem={({ item }: { item: Message }) => (
+              <MessageBubble message={item} />
+            )}
+            onScrollToIndexFailed={(info: {
+              index: number;
+              highestMeasuredFrameIndex: number;
+              averageItemLength: number;
+            }) => {
+              // Wait for the list to render the items, then retry scrolling
+              const wait = new Promise((resolve) => setTimeout(resolve, 500));
+              wait.then(() => {
+                const sections = displayedSections;
+                if (sections.length > 0) {
+                  const sectionIndex = sections.length - 1;
+                  const lastSection = sections[sectionIndex];
+                  const itemIndex = Math.max(
+                    0,
+                    (lastSection.data?.length || 1) - 1,
+                  );
+                  try {
+                    listRef.current?.scrollToLocation({
+                      sectionIndex,
+                      itemIndex,
+                      viewPosition: 1,
+                      animated: true,
+                    });
+                  } catch (error) {
+                    // Final fallback: scroll to end
+                    listRef.current?.scrollToEnd({ animated: true });
+                  }
+                }
+              });
+            }}
+            renderSectionHeader={({ section }: any) => {
+              const showLoad = !!section.showLoadEarlier;
+              return (
+                <View>
+                  {showLoad && (
+                    <View style={{ alignItems: "center", marginBottom: 8 }}>
+                      <TouchableOpacity
+                        onPress={() => {
+                          const groups =
+                            chatUtils.groupMessagesByDate(messages);
+                          if (visibleDayCount === 0) {
+                            const next = Math.min(2, groups.length);
+                            setVisibleDayCount(next);
+                            setVisibleDayCountFor(
+                              ticketNumber as string | undefined,
+                              next,
+                            );
+                          } else {
+                            setVisibleDayCount((v: number) => {
+                              const next = Math.min(groups.length, v + 1);
+                              setVisibleDayCountFor(
+                                ticketNumber as string | undefined,
+                                next,
+                              );
+                              return next;
+                            });
+                          }
+                        }}
+                        style={styles.loadEarlier}
+                      >
+                        <Text style={typography.body3}>Load earlier</Text>
+                      </TouchableOpacity>
+                    </View>
+                  )}
+                  <DateSeparator date={section.title} />
+                </View>
+              );
+            }}
+            contentContainerStyle={{ padding: 12, paddingBottom: 200 }}
+            refreshing={refreshing}
+            onRefresh={() => {
+              // Pull-to-refresh now expands the visible day groups.
+              setRefreshing(true);
+              setTimeout(() => {
+                const groups = chatUtils.groupMessagesByDate(messages);
+                if (visibleDayCount === 0) {
+                  // first pull: switch to day pagination and show today + yesterday
+                  const next = Math.min(2, groups.length);
+                  setVisibleDayCount(next);
+                  setVisibleDayCountFor(
+                    ticketNumber as string | undefined,
+                    next,
+                  );
+                } else {
+                  // subsequent pulls: load one more earlier day
+                  setVisibleDayCount((v: number) => {
+                    const next = Math.min(groups.length, v + 1);
+                    setVisibleDayCountFor(
+                      ticketNumber as string | undefined,
+                      next,
+                    );
+                    return next;
+                  });
+                }
+                setRefreshing(false);
+              }, 700);
+            }}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          />
+        </View>
+        {/* AI suggestion chip */}
+        {aiSuggestions?.trim()?.length > 0 && (
+          <View style={styles.suggestionContainer}>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <TouchableOpacity
+                onPress={() => {
+                  setText(aiSuggestions);
+                  setAiSuggestions("");
+                }}
+                style={styles.suggestionChip}
+              >
+                <Text numberOfLines={2} style={typography.body3}>
+                  {aiSuggestions}
+                </Text>
+              </TouchableOpacity>
+            </ScrollView>
+          </View>
+        )}
+
+        <View style={styles.inputRow}>
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            style={[
+              typography.body3,
+              styles.textInput,
+              { color: themeColors.dark1 },
+            ]}
+            placeholder="Type a message..."
+            placeholderTextColor={themeColors.dark3}
+            multiline
+          />
+          <TouchableOpacity
+            onPress={() => {
+              if (text.trim().length === 0) return;
+
+              const now = new Date();
+              const newMsg: Message = {
+                id: messages.length + 1,
+                name: "You",
+                text: text.trim(),
+                sender: "user",
+                timestamp: now.toLocaleString(), // Keep consistent with dummy messages
+              };
+
+              setText("");
+
+              // Update messages first
+              const updatedMessages = [...messages, newMsg];
+              setMessages(updatedMessages);
+
+              // Then update pagination state in the next tick to avoid render conflicts
+              requestAnimationFrame(() => {
+                const groups = chatUtils.groupMessagesByDate(updatedMessages);
+
+                // Always show all days to ensure new message is visible
+                setVisibleDayCount(groups.length);
+                setVisibleMessageCount(updatedMessages.length);
+
+                // Update context pagination state
+                setVisibleDayCountFor(
+                  ticketNumber as string | undefined,
+                  groups.length,
+                );
+
+                // Scroll to bottom after state updates
+                setTimeout(() => scrollToBottom(true), 100);
+              });
+            }}
+            style={styles.sendButton}
+          >
+            <Feathericons name="send" size={20} color={themeColors.white} />
+          </TouchableOpacity>
+        </View>
+
+        {/* helper components and functions */}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const DateSeparator = ({ date }: { date: string }) => (
+  <View style={styles.dateSeparator}>
+    <Text style={typography.caption}>{date}</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: themeColors.background,
+  },
+  messagesContainer: {
+    flex: 1,
+    marginBottom: 10,
+  },
+  loadEarlier: {
+    alignSelf: "center",
+    padding: 8,
+    marginBottom: 8,
+  },
+  suggestionContainer: {
+    borderTopWidth: 1,
+    borderColor: themeColors.mutedBorder,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: themeColors.background,
+  },
+  suggestionChip: {
+    backgroundColor: themeColors["green-50"],
+    padding: 8,
+    borderRadius: 8,
+    maxWidth: 300,
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    padding: 12,
+    borderTopWidth: 1,
+    borderColor: themeColors.mutedBorder,
+    backgroundColor: themeColors.background,
+  },
+  textInput: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    padding: 8,
+    backgroundColor: themeColors.white,
+    borderRadius: 8,
+  },
+  sendButton: {
+    marginLeft: 8,
+    backgroundColor: themeColors["green-500"],
+    borderRadius: 24,
+    padding: 10,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  dateSeparator: {
+    alignItems: "center",
+    marginVertical: 8,
+  },
+});
+
+const ChatScreenWithProvider = () => (
+  <ChatPaginationProvider>
+    <ChatScreen />
+  </ChatPaginationProvider>
+);
+
+export default ChatScreenWithProvider;

--- a/app/app/chat.tsx
+++ b/app/app/chat.tsx
@@ -47,7 +47,9 @@ const ChatScreen = () => {
   // compute which sections to display based on pagination state
   const displayedSections = React.useMemo(() => {
     const groups = chatUtils.groupMessagesByDate(messages); // [{date, items}]
-    if (groups.length === 0) return [];
+    if (groups.length === 0) {
+      return [];
+    }
 
     if (visibleDayCount > 0) {
       // if visibleDayCount covers all groups, return everything
@@ -87,7 +89,9 @@ const ChatScreen = () => {
         setTimeout(
           () => {
             const sections = displayedSections;
-            if (!sections || sections.length === 0) return;
+            if (!sections || sections.length === 0) {
+              return;
+            }
 
             const sectionIndex = sections.length - 1;
             const lastSection = sections[sectionIndex];
@@ -119,7 +123,9 @@ const ChatScreen = () => {
   // sync initial visibleDayCount from context for this ticket
   useEffect(() => {
     const v = getVisibleDayCount(ticketNumber as string | undefined);
-    if (v && v > 0) setVisibleDayCount(v);
+    if (v && v > 0) {
+      setVisibleDayCount(v);
+    }
   }, [getVisibleDayCount, ticketNumber]);
   useEffect(() => {
     // scroll to bottom on mount and when displayedSections change
@@ -283,7 +289,9 @@ const ChatScreen = () => {
           />
           <TouchableOpacity
             onPress={() => {
-              if (text.trim().length === 0) return;
+              if (text.trim().length === 0) {
+                return;
+              }
 
               const now = new Date();
               const newMsg: Message = {

--- a/app/components/avatar.tsx
+++ b/app/components/avatar.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import MDCommunityicons from "@expo/vector-icons/MaterialCommunityIcons";
+import typography from "@/styles/typography";
+import themeColors from "@/styles/colors";
+
+type AvatarProps = {
+  initials?: string;
+  size?: number;
+  backgroundColor?: string;
+  showAdminBadge?: boolean;
+};
+
+const Avatar: React.FC<AvatarProps> = ({
+  initials = "U",
+  size = 48,
+  backgroundColor = themeColors["green-500"],
+  showAdminBadge = false,
+}) => {
+  const borderRadius = Math.round(size / 2);
+  const badgeSize = Math.round(size * 0.56);
+  return (
+    <View style={{ width: size, height: size, position: "relative" }}>
+      {showAdminBadge && (
+        <View
+          style={[
+            styles.adminBadge,
+            {
+              width: badgeSize,
+              height: badgeSize,
+              borderRadius: badgeSize / 2,
+            },
+          ]}
+        >
+          <MDCommunityicons
+            name="crown"
+            size={Math.round(badgeSize * 0.55)}
+            color={"white"}
+          />
+        </View>
+      )}
+
+      <View
+        style={[
+          styles.circle,
+          {
+            width: size,
+            height: size,
+            borderRadius,
+            backgroundColor,
+            borderColor: themeColors.white,
+            borderWidth: 2,
+            justifyContent: "center",
+            alignItems: "center",
+          },
+        ]}
+      >
+        <Text style={[typography.body1, { color: themeColors.white }]}>
+          {initials}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  circle: {},
+  adminBadge: {
+    position: "absolute",
+    top: -12,
+    left: "50%",
+    marginLeft: -14,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 2,
+  },
+});
+
+export default Avatar;

--- a/app/components/chat/header-options.tsx
+++ b/app/components/chat/header-options.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { TouchableOpacity, Alert } from "react-native";
+import { useSQLiteContext } from "expo-sqlite";
+import Feathericons from "@expo/vector-icons/Feather";
+import { api } from "@/services/api";
+import { useAuth } from "@/contexts/AuthContext";
+import { dao } from "@/database/dao";
+
+type Props = {
+  ticketID?: string | number;
+};
+
+const HeaderOptions = ({ ticketID }: Props) => {
+  const { user } = useAuth();
+  const db = useSQLiteContext();
+
+  const onYes = async () => {
+    try {
+      const ticket = dao.ticket.findByTicketNumber(db, ticketID as string);
+      if (!ticket) {
+        throw new Error("Ticket not found");
+      }
+      await api.closeTicket(user?.accessToken, ticket.id);
+    } catch (error) {
+      console.error("Error closing ticket:", error);
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      style={{ paddingHorizontal: 8, paddingVertical: 6 }}
+      onPress={() => {
+        const id = ticketID ?? "unknown";
+        Alert.alert("Options", `Would you like to close this ticket: ${id}?`, [
+          { text: "Yes", onPress: onYes },
+          { text: "No", style: "cancel" },
+        ]);
+      }}
+      accessibilityLabel="More options"
+      accessibilityRole="button"
+    >
+      <Feathericons name="check" size={22} color="black" />
+    </TouchableOpacity>
+  );
+};
+
+export default HeaderOptions;

--- a/app/components/chat/header-options.tsx
+++ b/app/components/chat/header-options.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Alert } from "react-native";
 import { useSQLiteContext } from "expo-sqlite";
+import { useRouter } from "expo-router";
 import Feathericons from "@expo/vector-icons/Feather";
 import { api } from "@/services/api";
 import { useAuth } from "@/contexts/AuthContext";
@@ -16,6 +17,7 @@ const HeaderOptions = ({ ticketID }: Props) => {
   const { user } = useAuth();
   const { updateTicket } = useTicket();
   const db = useSQLiteContext();
+  const router = useRouter();
 
   const handleCloseTicket = async () => {
     try {
@@ -31,6 +33,8 @@ const HeaderOptions = ({ ticketID }: Props) => {
         resolvedAt: resData.resolved_at,
         resolvedBy: user.id,
       });
+      // Redirect to inbox after closing with active tab as 'responded'
+      router.replace("/inbox?initTab=resolved");
     } catch (error) {
       console.error("Error closing ticket:", error);
     }

--- a/app/components/chat/header-options.tsx
+++ b/app/components/chat/header-options.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { TouchableOpacity, Alert } from "react-native";
+import { View, Alert } from "react-native";
 import { useSQLiteContext } from "expo-sqlite";
 import Feathericons from "@expo/vector-icons/Feather";
 import { api } from "@/services/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { dao } from "@/database/dao";
+import { DropdownMenu, MenuItem } from "../dropdown-menu";
+import { useTicket } from "@/contexts/TicketContext";
 
 type Props = {
   ticketID?: string | number;
@@ -12,35 +14,44 @@ type Props = {
 
 const HeaderOptions = ({ ticketID }: Props) => {
   const { user } = useAuth();
+  const { updateTicket } = useTicket();
   const db = useSQLiteContext();
 
-  const onYes = async () => {
+  const handleCloseTicket = async () => {
     try {
       const ticket = dao.ticket.findByTicketNumber(db, ticketID as string);
       if (!ticket) {
         throw new Error("Ticket not found");
       }
-      await api.closeTicket(user?.accessToken, ticket.id);
+      const { ticket: resData } = await api.closeTicket(
+        user?.accessToken,
+        ticket.id,
+      );
+      updateTicket(ticket.id, {
+        resolvedAt: resData.resolved_at,
+        resolvedBy: user.id,
+      });
     } catch (error) {
       console.error("Error closing ticket:", error);
     }
   };
 
+  const onCloseTicket = () => {
+    const id = ticketID ?? "unknown";
+    Alert.alert("Close Ticket", `Would you like to close this ticket: ${id}?`, [
+      { text: "Yes", onPress: handleCloseTicket },
+      { text: "No", style: "cancel" },
+    ]);
+  };
+
   return (
-    <TouchableOpacity
-      style={{ paddingHorizontal: 8, paddingVertical: 6 }}
-      onPress={() => {
-        const id = ticketID ?? "unknown";
-        Alert.alert("Options", `Would you like to close this ticket: ${id}?`, [
-          { text: "Yes", onPress: onYes },
-          { text: "No", style: "cancel" },
-        ]);
-      }}
-      accessibilityLabel="More options"
-      accessibilityRole="button"
-    >
-      <Feathericons name="check" size={22} color="black" />
-    </TouchableOpacity>
+    <View style={{ paddingHorizontal: 8, paddingVertical: 6 }}>
+      <DropdownMenu
+        trigger={<Feathericons name="more-vertical" size={22} color="black" />}
+      >
+        <MenuItem onPress={onCloseTicket}>Close Ticket</MenuItem>
+      </DropdownMenu>
+    </View>
   );
 };
 

--- a/app/components/chat/header-options.tsx
+++ b/app/components/chat/header-options.tsx
@@ -49,6 +49,7 @@ const HeaderOptions = ({ ticketID }: Props) => {
       updateTicket(ticket.id, {
         resolvedAt: resData.resolved_at,
         resolvedBy: user.id,
+        unreadCount: 0,
       });
       // Redirect to inbox after closing with active tab as 'responded'
       router.replace("/inbox?initTab=resolved");

--- a/app/components/chat/message-bubble.tsx
+++ b/app/components/chat/message-bubble.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { Text, View, StyleSheet } from "react-native";
+import Avatar from "@/components/avatar";
+import typography from "@/styles/typography";
+import themeColors from "@/styles/colors";
+import { initialsFromName } from "@/utils/string";
+import { Message } from "@/utils/chat";
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+const MessageBubble = ({ message }: MessageBubbleProps) => {
+  const isUser = message.sender === "user";
+
+  if (isUser) {
+    return (
+      <View style={[styles.messageRow, styles.rowRight]}>
+        <View style={[styles.bubble, styles.bubbleRight]}>
+          <View style={styles.tailRight} />
+          <Text style={[typography.body3, styles.userText]}>
+            {message.text}
+          </Text>
+          <Text style={[typography.caption, styles.timestamp]}>
+            {message.timestamp}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.messageRow, styles.rowLeft]}>
+      <Avatar initials={initialsFromName(message?.name)} size={32} />
+      <View style={[styles.bubble, styles.bubbleLeft]}>
+        <View style={styles.tailLeft} />
+        <Text style={[typography.body3, styles.name]}>{message.name}</Text>
+        <Text style={typography.body3}>{message.text}</Text>
+        <Text style={[typography.caption, styles.timestamp]}>
+          {message.timestamp}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  messageRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    marginVertical: 6,
+    maxWidth: "100%",
+  },
+  rowLeft: {
+    justifyContent: "flex-start",
+  },
+  rowRight: {
+    justifyContent: "flex-end",
+  },
+  bubble: {
+    maxWidth: "82%",
+    padding: 10,
+    borderRadius: 8,
+    marginHorizontal: 6,
+  },
+  bubbleLeft: {
+    backgroundColor: themeColors.light3,
+    marginLeft: 4,
+  },
+  bubbleRight: {
+    backgroundColor: themeColors["green-500"],
+    alignSelf: "flex-end",
+    // 8px margin from screen edge before tail
+    marginRight: 8,
+  },
+  userText: {
+    color: themeColors.white,
+  },
+  avatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    marginHorizontal: 6,
+  },
+  tailLeft: {
+    position: "absolute",
+    left: -6,
+    bottom: 6,
+    width: 0,
+    height: 0,
+    borderTopWidth: 6,
+    borderTopColor: "transparent",
+    borderRightWidth: 6,
+    borderRightColor: themeColors.light3,
+    borderBottomWidth: 6,
+    borderBottomColor: "transparent",
+  },
+  tailRight: {
+    position: "absolute",
+    right: -6,
+    bottom: 6,
+    width: 0,
+    height: 0,
+    borderTopWidth: 6,
+    borderTopColor: "transparent",
+    borderLeftWidth: 6,
+    borderLeftColor: themeColors["green-500"],
+    borderBottomWidth: 6,
+    borderBottomColor: "transparent",
+  },
+  name: {
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  timestamp: {
+    marginTop: 6,
+    fontSize: 11,
+    color: themeColors.dark3,
+    alignSelf: "flex-end",
+  },
+});
+
+export default MessageBubble;

--- a/app/components/dropdown-menu.tsx
+++ b/app/components/dropdown-menu.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useRef, ReactNode } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Modal,
+  StyleSheet,
+  Platform,
+} from "react-native";
+import themeColors from "@/styles/colors";
+import typography from "@/styles/typography";
+
+type MenuItemProps = {
+  onPress: () => void;
+  children: ReactNode;
+  destructive?: boolean;
+};
+
+export const MenuItem: React.FC<MenuItemProps> = ({
+  onPress,
+  children,
+  destructive = false,
+}: MenuItemProps) => {
+  return (
+    <TouchableOpacity
+      style={styles.menuItem}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
+      <Text
+        style={[
+          styles.menuItemText,
+          destructive && styles.menuItemTextDestructive,
+        ]}
+      >
+        {children}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+type DropdownMenuProps = {
+  trigger: ReactNode;
+  children: ReactNode;
+};
+
+export const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  trigger,
+  children,
+}: DropdownMenuProps) => {
+  const [visible, setVisible] = useState(false);
+  const triggerRef = useRef<TouchableOpacity>(null);
+  const [triggerPosition, setTriggerPosition] = useState({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  });
+
+  const handleOpen = () => {
+    triggerRef.current?.measure(
+      (
+        fx: number,
+        fy: number,
+        width: number,
+        height: number,
+        px: number,
+        py: number,
+      ) => {
+        setTriggerPosition({ x: px, y: py, width, height });
+        setVisible(true);
+      },
+    );
+  };
+
+  const handleClose = () => setVisible(false);
+
+  const handleLayout = () => {
+    if (triggerRef.current) {
+      triggerRef.current.measure(
+        (
+          fx: number,
+          fy: number,
+          width: number,
+          height: number,
+          px: number,
+          py: number,
+        ) => {
+          setTriggerPosition({ x: px, y: py, width, height });
+        },
+      );
+    }
+  };
+
+  // Wrap children to automatically close menu on press
+  const enhancedChildren = React.Children.map(children, (child: any) => {
+    if (React.isValidElement(child) && child.type === MenuItem) {
+      return React.cloneElement(child as React.ReactElement<MenuItemProps>, {
+        onPress: () => {
+          handleClose();
+          child.props.onPress();
+        },
+      });
+    }
+    return child;
+  });
+
+  return (
+    <>
+      <TouchableOpacity
+        ref={triggerRef}
+        onPress={handleOpen}
+        onLayout={handleLayout}
+        activeOpacity={0.7}
+        accessibilityLabel="Menu"
+        accessibilityRole="button"
+      >
+        {trigger}
+      </TouchableOpacity>
+
+      <Modal
+        transparent
+        visible={visible}
+        animationType="fade"
+        onRequestClose={handleClose}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={handleClose}
+        >
+          <View
+            style={[
+              styles.menuContainer,
+              {
+                top: triggerPosition.y + triggerPosition.height,
+                left: triggerPosition.x + triggerPosition.width - 200, // Align to right edge
+              },
+            ]}
+          >
+            {enhancedChildren}
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.3)",
+  },
+  menuContainer: {
+    position: "absolute",
+    backgroundColor: themeColors.white,
+    borderRadius: 8,
+    minWidth: 200,
+    maxWidth: 280,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: themeColors.borderLight,
+    ...Platform.select({
+      ios: {
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 8,
+      },
+      web: {
+        boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.25)",
+      },
+    }),
+  },
+  menuItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  menuItemText: {
+    ...typography.body,
+    fontSize: 16,
+    color: themeColors.textPrimary,
+  },
+  menuItemTextDestructive: {
+    color: "#dc2626", // red-600 for destructive actions
+  },
+});

--- a/app/components/inbox/search.tsx
+++ b/app/components/inbox/search.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { View, TextInput, StyleSheet } from "react-native";
+import Feathericons from "@expo/vector-icons/Feather";
+import themeColors from "@/styles/colors";
+import typography from "@/styles/typography";
+
+const Search: React.FC<{ value: string; onChange: (v: string) => void }> = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) => {
+  return (
+    <View style={styles.searchContainer}>
+      <Feathericons
+        name="search"
+        size={20}
+        color={themeColors.dark4}
+        style={styles.searchIcon}
+      />
+      <TextInput
+        placeholder="Search"
+        placeholderTextColor={themeColors.dark4}
+        value={value}
+        onChangeText={onChange}
+        style={[styles.searchInput, typography.body2]}
+        testID="inbox-search"
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  searchContainer: {
+    position: "relative",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  searchIcon: {
+    position: "absolute",
+    top: "25%",
+    left: 24,
+    zIndex: 1,
+  },
+  searchInput: {
+    backgroundColor: themeColors.white,
+    borderRadius: 40,
+    paddingVertical: 8,
+    paddingLeft: 32,
+    paddingRight: 16,
+    borderWidth: 1,
+    borderColor: themeColors.mutedBorder,
+  },
+});
+
+export default Search;

--- a/app/components/inbox/tabs-button.tsx
+++ b/app/components/inbox/tabs-button.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { View, TouchableOpacity, Text, StyleSheet } from "react-native";
+import themeColors from "@/styles/colors";
+import typography from "@/styles/typography";
+
+export const TabsButton: React.FC<{
+  activeTab: string;
+  onChange: (tab: string) => void;
+}> = ({
+  activeTab,
+  onChange,
+}: {
+  activeTab: string;
+  onChange: (tab: string) => void;
+}) => {
+  return (
+    <View style={styles.TabsContainer}>
+      <TouchableOpacity
+        style={[
+          styles.tabItem,
+          activeTab === "open" ? styles.tabActive : styles.tabInactive,
+        ]}
+        onPress={() => onChange("open")}
+      >
+        <Text
+          style={
+            activeTab === "open"
+              ? [typography.body3, typography.textGreen500]
+              : [typography.body3, { color: themeColors.dark3 }]
+          }
+        >
+          Pending
+        </Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[
+          styles.tabItem,
+          activeTab === "resolved" ? styles.tabActive : styles.tabInactive,
+        ]}
+        onPress={() => onChange("resolved")}
+      >
+        <Text
+          style={
+            activeTab === "resolved"
+              ? [typography.body3, typography.textGreen500]
+              : [typography.body3, { color: themeColors.dark3 }]
+          }
+        >
+          Responded
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  TabsContainer: {
+    width: "100%",
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    borderRadius: 40,
+    backgroundColor: themeColors["green-50"],
+    justifyContent: "space-between",
+  },
+  tabItem: {
+    width: "48%",
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    borderRadius: 40,
+    alignItems: "center",
+  },
+  tabActive: {
+    backgroundColor: themeColors.white,
+  },
+  tabInactive: {
+    backgroundColor: themeColors["green-50"],
+  },
+});
+
+export default TabsButton;

--- a/app/components/inbox/ticket-item.tsx
+++ b/app/components/inbox/ticket-item.tsx
@@ -20,7 +20,7 @@ const TicketItem: React.FC<{
   // Compute display values from API response
   const isUnread = ticket.unreadCount ?? 0;
   const messageContent = ticket.message?.body || "";
-  const messageTimestamp = ticket.lastMessageAt;
+  const messageTimestamp = ticket.message?.timestamp || ticket.createdAt;
   const respondedBy = ticket.resolver;
 
   return (

--- a/app/components/inbox/ticket-item.tsx
+++ b/app/components/inbox/ticket-item.tsx
@@ -5,28 +5,7 @@ import themeColors from "@/styles/colors";
 import { formatTime, formatResolved } from "@/utils/time";
 import { initialsFromName } from "@/utils/string";
 import Avatar from "@/components/avatar";
-
-type Customer = { id: number; name: string };
-type User = { id: number; name: string } | null;
-type Message = { id: number; body: string };
-
-export type Ticket = {
-  id: number;
-  ticket_number: string;
-  customer: Customer;
-  message: Message;
-  status: string;
-  created_at: string;
-  resolved_at: string | null;
-  resolver: User;
-  last_message_at: string;
-  // Computed properties for backward compatibility
-  ticketNumber?: string;
-  unreadMessages?: number;
-  lastMessage?: { content: string; timestamp: string };
-  resolvedAt?: string | null;
-  respondedBy?: User;
-};
+import { Ticket } from "@/database/dao/types/ticket";
 
 const TicketItem: React.FC<{
   ticket: Ticket;
@@ -39,10 +18,9 @@ const TicketItem: React.FC<{
   onPress: (t: Ticket) => void;
 }) => {
   // Compute display values from API response
-  const ticketNumber = ticket.ticket_number;
-  const isUnread = ticket.unreadMessages ?? 0;
+  const isUnread = ticket.unreadCount ?? 0;
   const messageContent = ticket.message?.body || "";
-  const messageTimestamp = ticket.last_message_at;
+  const messageTimestamp = ticket.lastMessageAt;
   const respondedBy = ticket.resolver;
 
   return (
@@ -119,7 +97,7 @@ const TicketItem: React.FC<{
       </View>
       <View style={styles.ticketFooter}>
         <Text style={[typography.caption1, { color: themeColors.dark3 }]}>
-          {ticketNumber}
+          {ticket.ticketNumber}
         </Text>
         <View style={[styles.flexRow]}>
           <Text style={[typography.body4, { color: themeColors.textPrimary }]}>

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -25,6 +25,7 @@ interface User {
   isActive: boolean;
   invitationStatus?: string;
   administrativeLocation?: AdministrativeLocation | null;
+  accessToken?: string;
 }
 
 interface AuthContextType {
@@ -87,6 +88,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         isActive: profileDB.isActive,
         invitationStatus: profileDB.invitationStatus,
         administrativeLocation: adm,
+        accessToken: profileDB.accessToken,
       });
     }
 
@@ -121,6 +123,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         isActive: apiData.is_active,
         invitationStatus: apiData.invitation_status,
         administrativeLocation: apiData.administrative_location,
+        accessToken: accessToken,
       };
 
       setUser(userData);
@@ -129,10 +132,14 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         router.replace("/home");
       }
     } catch (error) {
-      console.error("Auth validation error:", error);
-      if (segments[0] !== "login" && routeToken) {
-        router.replace("/login");
+      console.log("test");
+      setUser(null);
+      setIsValid(false);
+      const isHealthy = checkDatabaseHealth();
+      if (isHealthy) {
+        forceClearDatabase();
       }
+      router.replace("/login");
     }
   }, [user, segments, router, routeToken, isValid]);
 

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -8,7 +8,6 @@ import React, {
   ReactNode,
 } from "react";
 import { useRouter, useSegments, useLocalSearchParams } from "expo-router";
-import { useSQLiteContext } from "expo-sqlite";
 import { api } from "@/services/api";
 import { DAOManager } from "@/database/dao";
 import { forceClearDatabase, checkDatabaseHealth } from "@/database/utils";
@@ -46,9 +45,9 @@ const validJSONString = (str: string): boolean => {
       .replace(/\\["\\\/bfnrtu]/g, "@")
       .replace(
         /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
-        "]"
+        "]",
       )
-      .replace(/(?:^|:|,)(?:\s*\[)+/g, "")
+      .replace(/(?:^|:|,)(?:\s*\[)+/g, ""),
   );
 };
 
@@ -142,10 +141,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       if (segments[0] !== "login" && routeToken) {
         setUser(null);
         setIsValid(false);
-        const isHealthy = checkDatabaseHealth();
-        if (isHealthy) {
-          forceClearDatabase();
-        }
         router.replace("/login");
       }
     }
@@ -160,7 +155,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     const handleUnauthorized = () => {
       // perform logout; don't await here to avoid blocking
       logout().catch((err) =>
-        console.error("Error during auto-logout (unauthorized):", err)
+        console.error("Error during auto-logout (unauthorized):", err),
       );
     };
 
@@ -217,7 +212,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       const isHealthy = checkDatabaseHealth(db);
       console.log(
         "Database health check:",
-        isHealthy ? "✅ Healthy" : "⚠️ Issues detected"
+        isHealthy ? "✅ Healthy" : "⚠️ Issues detected",
       );
 
       // Try force clear (which includes multiple fallback strategies)
@@ -227,10 +222,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         console.error("Failed to clear database during logout:", result.error);
         // Don't throw here - logout should still succeed even if DB clear fails
         console.warn(
-          "Logout completed but database clear failed - data may persist"
+          "Logout completed but database clear failed - data may persist",
         );
         console.log(
-          "💡 User data will be cleared on next app restart when migrations run"
+          "💡 User data will be cleared on next app restart when migrations run",
         );
       } else {
         console.log("✅ Database cleared successfully during logout");
@@ -239,7 +234,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       console.error("Error during logout database clear:", error);
       // Don't throw - logout should still succeed even if DB clear fails
       console.warn(
-        "Logout completed but encountered error during database clear"
+        "Logout completed but encountered error during database clear",
       );
       console.log("💡 User data will be cleared on next app restart");
     }

--- a/app/contexts/ChatPaginationContext.tsx
+++ b/app/contexts/ChatPaginationContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+type Store = Record<string, number>;
+
+type ContextShape = {
+  getVisibleDayCount: (ticketId?: string) => number;
+  setVisibleDayCountFor: (ticketId: string | undefined, value: number) => void;
+};
+
+const ChatPaginationContext = createContext<ContextShape>({
+  getVisibleDayCount: () => 0,
+  setVisibleDayCountFor: () => {},
+});
+
+export const ChatPaginationProvider = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => {
+  const [store, setStore] = useState<Store>({});
+
+  const getVisibleDayCount = (ticketId?: string) => {
+    const key = ticketId ?? "global";
+    return store[key] ?? 0;
+  };
+
+  const setVisibleDayCountFor = (
+    ticketId: string | undefined,
+    value: number,
+  ) => {
+    const key = ticketId ?? "global";
+    setStore((s: Store) => ({ ...s, [key]: value }));
+  };
+
+  return (
+    <ChatPaginationContext.Provider
+      value={{ getVisibleDayCount, setVisibleDayCountFor }}
+    >
+      {children}
+    </ChatPaginationContext.Provider>
+  );
+};
+
+export const useChatPagination = () => useContext(ChatPaginationContext);

--- a/app/contexts/TicketContext.tsx
+++ b/app/contexts/TicketContext.tsx
@@ -1,6 +1,6 @@
-import { dao } from "@/database/dao";
+import { DAOManager } from "@/database/dao";
 import { CreateTicketData, Ticket } from "@/database/dao/types/ticket";
-import { useSQLiteContext } from "expo-sqlite";
+import { useDatabase } from "@/database/context";
 import React, {
   createContext,
   useCallback,
@@ -8,6 +8,7 @@ import React, {
   useEffect,
   useState,
   useRef,
+  useMemo,
   ReactNode,
 } from "react";
 
@@ -27,8 +28,11 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({
   children: ReactNode;
 }) => {
   const [tickets, setTickets] = useState([]);
-  const db = useSQLiteContext();
+  const db = useDatabase();
   const isMounted = useRef(true);
+
+  // Create DAO manager with database from context
+  const dao = useMemo(() => new DAOManager(db), [db]);
 
   useEffect(() => {
     return () => {
@@ -45,7 +49,7 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({
     } catch (error) {
       console.error("Error loading tickets:", error);
     }
-  }, [db]);
+  }, [db, dao]);
 
   useEffect(() => {
     loadTickets();
@@ -62,7 +66,7 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({
         console.error("Error creating ticket:", error);
       }
     },
-    [db],
+    [db, dao],
   );
 
   const updateTicket = useCallback(
@@ -78,7 +82,7 @@ export const TicketProvider: React.FC<{ children: ReactNode }> = ({
         console.error("Error updating ticket:", error);
       }
     },
-    [db],
+    [db, dao],
   );
 
   return (

--- a/app/contexts/TicketContext.tsx
+++ b/app/contexts/TicketContext.tsx
@@ -1,0 +1,89 @@
+import { dao } from "@/database/dao";
+import { CreateTicketData, Ticket } from "@/database/dao/types/ticket";
+import { useSQLiteContext } from "expo-sqlite";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  ReactNode,
+} from "react";
+
+const TicketContext = createContext(null);
+
+export const useTicket = () => {
+  const context = useContext(TicketContext);
+  if (!context) {
+    throw new Error("useTicket must be used within a TicketProvider");
+  }
+  return context;
+};
+
+export const TicketProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [tickets, setTickets] = useState([]);
+  const db = useSQLiteContext();
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  const loadTickets = useCallback(async () => {
+    try {
+      const result = await dao.ticket.findAll(db);
+      if (isMounted.current) {
+        setTickets(result);
+      }
+    } catch (error) {
+      console.error("Error loading tickets:", error);
+    }
+  }, [db]);
+
+  useEffect(() => {
+    loadTickets();
+  }, [loadTickets]);
+
+  const createTicket = useCallback(
+    async (data: CreateTicketData) => {
+      try {
+        const newTicket = await dao.ticket.create(db, data);
+        if (isMounted.current) {
+          setTickets((prev: Ticket[]) => [newTicket, ...prev]);
+        }
+      } catch (error) {
+        console.error("Error creating ticket:", error);
+      }
+    },
+    [db],
+  );
+
+  const updateTicket = useCallback(
+    async (id: number, data: Partial<CreateTicketData>) => {
+      try {
+        const success = await dao.ticket.update(db, id, data);
+        if (success && isMounted.current) {
+          setTickets((prev: Ticket[]) =>
+            prev.map((t) => (t.id === id ? { ...t, ...data } : t)),
+          );
+        }
+      } catch (error) {
+        console.error("Error updating ticket:", error);
+      }
+    },
+    [db],
+  );
+
+  return (
+    <TicketContext.Provider value={{ tickets, createTicket, updateTicket }}>
+      {children}
+    </TicketContext.Provider>
+  );
+};

--- a/app/database/config.ts
+++ b/app/database/config.ts
@@ -1,2 +1,2 @@
-export const DATABASE_VERSION: number = 1;
+export const DATABASE_VERSION: number = 2;
 export const DATABASE_NAME: string = "agriconnect.db";

--- a/app/database/dao/customerUserDAO.ts
+++ b/app/database/dao/customerUserDAO.ts
@@ -7,12 +7,12 @@ import {
 } from "./types/customerUser";
 
 export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
-  constructor(db: SQLiteDatabase) {
-    super(db, "customer_users"); // Keep table name as is for now
+  constructor() {
+    super("customer_users"); // Keep table name as is for now
   }
 
-  create(data: CreateCustomerUserData): CustomerUser {
-    const stmt = this.db.prepareSync(
+  create(db: SQLiteDatabase, data: CreateCustomerUserData): CustomerUser {
+    const stmt = db.prepareSync(
       `INSERT INTO customer_users (
         phoneNumber, fullName, language, createdAt, updatedAt
       ) VALUES (?, ?, ?, ?, ?)`,
@@ -27,7 +27,7 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
         now,
       ]);
 
-      const user = this.findById(result.lastInsertRowId);
+      const user = this.findById(db, result.lastInsertRowId);
       if (!user) {
         throw new Error("Failed to retrieve created customer user");
       }
@@ -40,7 +40,11 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
     }
   }
 
-  update(id: number, data: UpdateCustomerUserData): boolean {
+  update(
+    db: SQLiteDatabase,
+    id: number,
+    data: UpdateCustomerUserData,
+  ): boolean {
     try {
       const updates: string[] = [];
       const values: any[] = [];
@@ -66,7 +70,7 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
       values.push(new Date().toISOString());
       values.push(id);
 
-      const stmt = this.db.prepareSync(
+      const stmt = db.prepareSync(
         `UPDATE customer_users SET ${updates.join(", ")} WHERE id = ?`,
       );
       try {
@@ -82,8 +86,11 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
   }
 
   // Find user by phone number
-  findByPhoneNumber(phoneNumber: string): CustomerUser | null {
-    const stmt = this.db.prepareSync(
+  findByPhoneNumber(
+    db: SQLiteDatabase,
+    phoneNumber: string,
+  ): CustomerUser | null {
+    const stmt = db.prepareSync(
       "SELECT * FROM customer_users WHERE phoneNumber = ?",
     );
     try {
@@ -98,8 +105,8 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
   }
 
   // Search customers by name (partial match)
-  searchByName(name: string): CustomerUser[] {
-    const stmt = this.db.prepareSync(
+  searchByName(db: SQLiteDatabase, name: string): CustomerUser[] {
+    const stmt = db.prepareSync(
       "SELECT * FROM customer_users WHERE fullName LIKE ? ORDER BY fullName",
     );
     try {
@@ -114,8 +121,8 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
   }
 
   // Get customers by language
-  findByLanguage(language: string): CustomerUser[] {
-    const stmt = this.db.prepareSync(
+  findByLanguage(db: SQLiteDatabase, language: string): CustomerUser[] {
+    const stmt = db.prepareSync(
       "SELECT * FROM customer_users WHERE language = ? ORDER BY fullName",
     );
     try {
@@ -130,8 +137,8 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
   }
 
   // Get recent customers (ordered by creation date)
-  findRecent(limit: number = 10): CustomerUser[] {
-    const stmt = this.db.prepareSync(
+  findRecent(db: SQLiteDatabase, limit: number = 10): CustomerUser[] {
+    const stmt = db.prepareSync(
       "SELECT * FROM customer_users ORDER BY createdAt DESC LIMIT ?",
     );
     try {
@@ -146,7 +153,7 @@ export class CustomerUserDAO extends BaseDAOImpl<CustomerUser> {
   }
 
   // Update customer's language preference
-  updateLanguage(id: number, language: string): boolean {
-    return this.update(id, { language });
+  updateLanguage(db: SQLiteDatabase, id: number, language: string): boolean {
+    return this.update(db, id, { language });
   }
 }

--- a/app/database/dao/index.ts
+++ b/app/database/dao/index.ts
@@ -1,49 +1,34 @@
-import { SQLiteDatabase } from "expo-sqlite";
-import { getDatabase } from "../index";
 import { UserDAO } from "./userDAO";
 import { CustomerUserDAO } from "./customerUserDAO";
 import { MessageDAO } from "./messageDAO";
 import { ProfileDAO } from "./profileDAO";
+import { TicketDAO } from "./ticketDAO";
 
 /**
  * DAO Manager - Central access point for all database operations
  *
  * Usage:
- * const dao = DAOManager.getInstance();
- * const users = dao.user.findAll();
- * const messages = dao.message.getInbox(eoId);
+ * const db = useSQLiteContext(); // Get from React context
+ * const profile = dao.profile.getCurrentProfile(db);
+ * const messages = dao.message.getInbox(db, eoId);
  */
 export class DAOManager {
   private static instance: DAOManager;
-  private db: SQLiteDatabase;
 
   // DAO instances
   public readonly user: UserDAO;
   public readonly customerUser: CustomerUserDAO;
   public readonly message: MessageDAO;
   public readonly profile: ProfileDAO;
+  public readonly ticket: TicketDAO;
 
   private constructor() {
-    this.db = getDatabase();
-
-    // Verify database is properly initialized
-    if (!this.db) {
-      throw new Error("Failed to initialize database");
-    }
-
-    // Test database connection
-    try {
-      this.db.getFirstSync("SELECT 1 as test");
-    } catch (error) {
-      console.error("Database connection test failed:", error);
-      throw new Error("Database is not accessible");
-    }
-
-    // Initialize all DAOs
-    this.user = new UserDAO(this.db);
-    this.customerUser = new CustomerUserDAO(this.db);
-    this.message = new MessageDAO(this.db);
-    this.profile = new ProfileDAO(this.db);
+    // Initialize all DAOs without database dependency
+    this.user = new UserDAO();
+    this.customerUser = new CustomerUserDAO();
+    this.message = new MessageDAO();
+    this.profile = new ProfileDAO();
+    this.ticket = new TicketDAO();
   }
 
   /**
@@ -54,13 +39,6 @@ export class DAOManager {
       DAOManager.instance = new DAOManager();
     }
     return DAOManager.instance;
-  }
-
-  /**
-   * Get raw database instance (for advanced operations)
-   */
-  public getDatabase(): SQLiteDatabase {
-    return this.db;
   }
 
   /**

--- a/app/database/dao/ticketDAO.ts
+++ b/app/database/dao/ticketDAO.ts
@@ -22,13 +22,13 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
     const stmt = hasId
       ? db.prepareSync(
           `INSERT INTO tickets (
-            id, customerId, messageId, status, ticketNumber, unreadCount, lastMessageAt, createdAt, updatedAt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            id, customerId, messageId, status, ticketNumber, unreadCount, lastMessageAt, createdAt, resolvedAt, resolvedBy
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
       : db.prepareSync(
           `INSERT INTO tickets (
-            customerId, messageId, status, ticketNumber, unreadCount, lastMessageAt, createdAt, updatedAt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            customerId, messageId, status, ticketNumber, unreadCount, lastMessageAt, createdAt, resolvedAt, resolvedBy
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         );
 
     try {
@@ -43,7 +43,8 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
             data.unreadCount || 0,
             data.lastMessageAt || now,
             now,
-            now,
+            data.resolvedAt || null,
+            data.resolvedBy || null,
           ]
         : [
             data.customerId,
@@ -53,7 +54,8 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
             data.unreadCount || 0,
             data.lastMessageAt || now,
             now,
-            now,
+            data.resolvedAt || null,
+            data.resolvedBy || null,
           ];
 
       const result = stmt.executeSync(params);
@@ -296,6 +298,7 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
           resolvedAt: ticketData.resolvedAt,
           unreadCount: ticketData.unreadCount,
           lastMessageAt: ticketData.lastMessageAt,
+          resolvedBy: ticketData.resolvedBy,
         };
 
         this.update(db, existing.id, updateData);
@@ -310,6 +313,8 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
           ticketNumber: ticketData.ticketNumber,
           unreadCount: ticketData.unreadCount,
           lastMessageAt: ticketData.lastMessageAt,
+          resolvedAt: ticketData.resolvedAt,
+          resolvedBy: ticketData.resolvedBy,
         };
 
         return this.create(db, createData);

--- a/app/database/dao/ticketDAO.ts
+++ b/app/database/dao/ticketDAO.ts
@@ -141,6 +141,8 @@ export class TicketDAO extends BaseDAOImpl<Ticket> {
       ticketNumber: row.ticketNumber,
       unreadCount: row.unreadCount,
       lastMessageAt: row.lastMessageAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt || null,
     } as Ticket;
   }
 

--- a/app/database/dao/ticketDAO.ts
+++ b/app/database/dao/ticketDAO.ts
@@ -1,0 +1,321 @@
+import { SQLiteDatabase } from "expo-sqlite";
+import { BaseDAOImpl } from "./base";
+import { Ticket, CreateTicketData, UpdateTicketData } from "./types/ticket";
+
+/**
+ * TicketDAO - manages tickets table and returns richer Ticket objects
+ * that include joined customer, message and user information matching
+ * the `Ticket` type in `types/ticket.ts`.
+ */
+export class TicketDAO extends BaseDAOImpl<Ticket> {
+  constructor() {
+    super("tickets");
+  }
+
+  // Insert a ticket and return the full Ticket shape
+  create(db: SQLiteDatabase, data: CreateTicketData): Ticket {
+    const stmt = db.prepareSync(
+      `INSERT INTO tickets (
+        customerId, messageId, status, ticketNumber, unreadCount, lastMessageAt, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    try {
+      const now = new Date().toISOString();
+      const result = stmt.executeSync([
+        data.customerId,
+        data.messageId,
+        data.status,
+        data.ticketNumber,
+        data.unreadCount || 0,
+        data.lastMessageAt || now,
+        now,
+        now,
+      ]);
+
+      const id = result.lastInsertRowId;
+      const ticket = this.findById(db, id as number);
+      if (!ticket) {
+        throw new Error("Failed to retrieve created ticket");
+      }
+      return ticket;
+    } catch (error) {
+      console.error("Error creating ticket:", error);
+      throw error;
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  update(db: SQLiteDatabase, id: number, data: UpdateTicketData): boolean {
+    try {
+      const updates: string[] = [];
+      const values: any[] = [];
+
+      if (data.status !== undefined) {
+        updates.push("status = ?");
+        values.push(data.status);
+      }
+      if (data.resolvedAt !== undefined) {
+        updates.push("resolvedAt = ?");
+        values.push(data.resolvedAt);
+      }
+      if (data.resolvedBy !== undefined) {
+        updates.push("resolvedBy = ?");
+        values.push(data.resolvedBy);
+      }
+      if (data.unreadCount !== undefined) {
+        updates.push("unreadCount = ?");
+        values.push(data.unreadCount);
+      }
+      if (data.lastMessageAt !== undefined) {
+        updates.push("lastMessageAt = ?");
+        values.push(data.lastMessageAt);
+      }
+
+      if (updates.length === 0) return false;
+
+      updates.push("updatedAt = ?");
+      values.push(new Date().toISOString());
+      values.push(id);
+
+      const stmt = db.prepareSync(
+        `UPDATE tickets SET ${updates.join(", ")} WHERE id = ?`,
+      );
+      try {
+        const result = stmt.executeSync(values);
+        return result.changes > 0;
+      } finally {
+        stmt.finalizeSync();
+      }
+    } catch (error) {
+      console.error("Error updating ticket:", error);
+      return false;
+    }
+  }
+
+  // Map a DB row to the Ticket shape using joins
+  private mapRowToTicket(row: any): Ticket {
+    return {
+      id: row.id,
+      customer: { id: row.customerId, name: row.customer_name },
+      message: row.messageId
+        ? {
+            id: row.messageId,
+            body: row.message_body,
+            timestamp: row.message_createdAt,
+          }
+        : null,
+      status: row.status,
+      resolvedAt: row.resolvedAt || null,
+      resolver: row.resolvedBy
+        ? { id: row.resolvedBy, name: row.resolver_name }
+        : null,
+      ticketNumber: row.ticketNumber,
+      unreadCount: row.unreadCount,
+      lastMessageAt: row.lastMessageAt,
+    } as Ticket;
+  }
+
+  // Find ticket with joins to include customer, message and user info
+  findById(db: SQLiteDatabase, id: number): Ticket | null {
+    const stmt = db.prepareSync(
+      `SELECT t.*, 
+        cu.fullName as customer_name,
+        m.id as messageId, m.body as message_body, m.createdAt as message_createdAt,
+        r.id as resolver_id, r.fullName as resolver_name
+      FROM tickets t
+      LEFT JOIN customer_users cu ON t.customerId = cu.id
+      LEFT JOIN messages m ON t.messageId = m.id
+      LEFT JOIN users r ON t.resolvedBy = r.id
+      WHERE t.id = ?`,
+    );
+    try {
+      const result = stmt.executeSync<any>([id]);
+      const row = result.getFirstSync();
+      if (!row) return null;
+      return this.mapRowToTicket(row);
+    } catch (error) {
+      console.error("Error finding ticket by id:", error);
+      return null;
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  // Return all tickets with joined data
+  findAll(db: SQLiteDatabase): Ticket[] {
+    const stmt = db.prepareSync(
+      `SELECT t.*, 
+        cu.fullName as customer_name,
+        m.id as messageId, m.body as message_body, m.createdAt as message_createdAt,
+        r.id as resolver_id, r.fullName as resolver_name
+      FROM tickets t
+      LEFT JOIN customer_users cu ON t.customerId = cu.id
+      LEFT JOIN messages m ON t.messageId = m.id
+      LEFT JOIN users r ON t.resolvedBy = r.id
+      ORDER BY t.createdAt DESC`,
+    );
+    try {
+      const result = stmt.executeSync<any>();
+      const rows = result.getAllSync();
+      return rows.map((r: any) => this.mapRowToTicket(r));
+    } catch (error) {
+      console.error("Error finding all tickets:", error);
+      return [];
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  // Find tickets by status with pagination
+  findByStatus(
+    db: SQLiteDatabase,
+    status: "open" | "resolved",
+    page: number = 1,
+    pageSize: number = 10,
+  ): { tickets: Ticket[]; total: number; page: number; size: number } {
+    const offset = (page - 1) * pageSize;
+
+    // Build WHERE clause based on status
+    const whereClause =
+      status === "open" ? "t.resolvedAt IS NULL" : "t.resolvedAt IS NOT NULL";
+
+    // Get total count
+    const countStmt = db.prepareSync(
+      `SELECT COUNT(*) as total FROM tickets t WHERE ${whereClause}`,
+    );
+
+    let total = 0;
+    try {
+      const countResult = countStmt.executeSync<any>();
+      const countRow = countResult.getFirstSync();
+      total = countRow?.total || 0;
+    } catch (error) {
+      console.error("Error counting tickets:", error);
+    } finally {
+      countStmt.finalizeSync();
+    }
+
+    // Get paginated tickets
+    const stmt = db.prepareSync(
+      `SELECT t.*, 
+        cu.fullName as customer_name,
+        m.id as messageId, m.body as message_body, m.createdAt as message_createdAt,
+        r.id as resolver_id, r.fullName as resolver_name
+      FROM tickets t
+      LEFT JOIN customer_users cu ON t.customerId = cu.id
+      LEFT JOIN messages m ON t.messageId = m.id
+      LEFT JOIN users r ON t.resolvedBy = r.id
+      WHERE ${whereClause}
+      ORDER BY t.lastMessageAt DESC, t.createdAt DESC
+      LIMIT ? OFFSET ?`,
+    );
+
+    try {
+      const result = stmt.executeSync<any>([pageSize, offset]);
+      const rows = result.getAllSync();
+      const tickets = rows.map((r: any) => this.mapRowToTicket(r));
+
+      return {
+        tickets,
+        total,
+        page,
+        size: pageSize,
+      };
+    } catch (error) {
+      console.error("Error finding tickets by status:", error);
+      return { tickets: [], total: 0, page, size: pageSize };
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  // Find ticket by ticketNumber
+  findByTicketNumber(db: SQLiteDatabase, ticketNumber: string): Ticket | null {
+    const stmt = db.prepareSync(
+      `SELECT t.*, 
+        cu.fullName as customer_name,
+        m.id as messageId, m.body as message_body, m.createdAt as message_createdAt,
+        r.id as resolver_id, r.fullName as resolver_name
+      FROM tickets t
+      LEFT JOIN customer_users cu ON t.customerId = cu.id
+      LEFT JOIN messages m ON t.messageId = m.id
+      LEFT JOIN users r ON t.resolvedBy = r.id
+      WHERE t.ticketNumber = ?`,
+    );
+
+    try {
+      const result = stmt.executeSync<any>([ticketNumber]);
+      const row = result.getFirstSync();
+      if (!row) return null;
+      return this.mapRowToTicket(row);
+    } catch (error) {
+      console.error("Error finding ticket by number:", error);
+      return null;
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  // Upsert ticket (insert or update based on ticketNumber)
+  upsert(db: SQLiteDatabase, ticketData: any): Ticket | null {
+    try {
+      // Check if ticket exists
+      const existing = this.findByTicketNumber(db, ticketData.ticketNumber);
+
+      if (existing) {
+        // Update existing ticket
+        const updateData: UpdateTicketData = {
+          status: ticketData.status,
+          resolvedAt: ticketData.resolvedAt,
+          unreadCount: ticketData.unreadCount,
+          lastMessageAt: ticketData.lastMessageAt,
+        };
+
+        this.update(db, existing.id, updateData);
+        return this.findById(db, existing.id);
+      } else {
+        // Create new ticket - need to ensure customer and message exist
+        const createData: CreateTicketData = {
+          customerId: ticketData.customerId,
+          messageId: ticketData.messageId,
+          status: ticketData.status,
+          ticketNumber: ticketData.ticketNumber,
+          unreadCount: ticketData.unreadCount,
+          lastMessageAt: ticketData.lastMessageAt,
+        };
+
+        return this.create(db, createData);
+      }
+    } catch (error) {
+      console.error("Error upserting ticket:", error);
+      return null;
+    }
+  }
+
+  // Bulk upsert tickets
+  bulkUpsert(db: SQLiteDatabase, tickets: any[]): number {
+    let count = 0;
+
+    try {
+      db.execSync("BEGIN TRANSACTION");
+
+      for (const ticketData of tickets) {
+        const result = this.upsert(db, ticketData);
+        if (result) count++;
+      }
+
+      db.execSync("COMMIT");
+    } catch (error) {
+      console.error("Error bulk upserting tickets:", error);
+      try {
+        db.execSync("ROLLBACK");
+      } catch (rollbackError) {
+        console.error("Error rolling back transaction:", rollbackError);
+      }
+    }
+
+    return count;
+  }
+}

--- a/app/database/dao/types/customerUser.ts
+++ b/app/database/dao/types/customerUser.ts
@@ -9,6 +9,7 @@ export interface CustomerUser {
 }
 
 export interface CreateCustomerUserData {
+  id?: number; // Optional: Can specify API's customer ID
   phoneNumber: string;
   fullName: string;
   language?: string;

--- a/app/database/dao/types/ticket.ts
+++ b/app/database/dao/types/ticket.ts
@@ -18,6 +18,7 @@ export type Ticket = {
 };
 
 export interface CreateTicketData {
+  id?: number;
   customerId: number;
   messageId: number;
   status: string;

--- a/app/database/dao/types/ticket.ts
+++ b/app/database/dao/types/ticket.ts
@@ -1,0 +1,36 @@
+type Customer = { id: number; name: string };
+type User = { id: number; name: string } | null;
+type Message = { id: number; body: string; timestamp: string } | null;
+
+export type Ticket = {
+  id: number;
+  customer: Customer;
+  message: Message;
+  status: string;
+  createdAt: string;
+  resolver: User;
+  ticketNumber: string;
+  unreadCount?: number;
+  lastMessageAt?: string;
+  lastMessage?: { content: string; timestamp: string };
+  resolvedAt?: string | null;
+  respondedBy?: User;
+};
+
+export interface CreateTicketData {
+  customerId: number;
+  messageId: number;
+  status: string;
+  ticketNumber: string;
+  unreadCount?: number;
+  lastMessageAt?: string;
+}
+
+export interface UpdateTicketData {
+  status?: string;
+  resolvedAt?: string | null;
+  resolvedBy?: number | null;
+  unreadCount?: number;
+  lastMessageAt?: string;
+  respondedById?: number | null;
+}

--- a/app/database/dao/types/ticket.ts
+++ b/app/database/dao/types/ticket.ts
@@ -11,7 +11,6 @@ export type Ticket = {
   resolver: User;
   ticketNumber: string;
   unreadCount?: number;
-  lastMessageAt?: string;
   lastMessage?: { content: string; timestamp: string };
   resolvedAt?: string | null;
   respondedBy?: User;
@@ -25,7 +24,6 @@ export interface CreateTicketData {
   status: string;
   ticketNumber: string;
   unreadCount?: number;
-  lastMessageAt?: string;
   resolvedAt?: string | null;
   resolvedBy?: number | null;
 }
@@ -35,5 +33,4 @@ export interface UpdateTicketData {
   resolvedAt?: string | null;
   resolvedBy?: number | null;
   unreadCount?: number;
-  lastMessageAt?: string;
 }

--- a/app/database/dao/types/ticket.ts
+++ b/app/database/dao/types/ticket.ts
@@ -25,6 +25,8 @@ export interface CreateTicketData {
   ticketNumber: string;
   unreadCount?: number;
   lastMessageAt?: string;
+  resolvedAt?: string | null;
+  resolvedBy?: number | null;
 }
 
 export interface UpdateTicketData {
@@ -33,5 +35,4 @@ export interface UpdateTicketData {
   resolvedBy?: number | null;
   unreadCount?: number;
   lastMessageAt?: string;
-  respondedById?: number | null;
 }

--- a/app/database/dao/types/ticket.ts
+++ b/app/database/dao/types/ticket.ts
@@ -15,6 +15,7 @@ export type Ticket = {
   lastMessage?: { content: string; timestamp: string };
   resolvedAt?: string | null;
   respondedBy?: User;
+  updatedAt?: string | null;
 };
 
 export interface CreateTicketData {

--- a/app/database/index.ts
+++ b/app/database/index.ts
@@ -56,18 +56,18 @@ export const migrateDbIfNeeded = (): SQLiteDatabase => {
     console.log("✅ Database initialized successfully");
   }
 
-  // Future migrations can be added here
-  // if (currentDbVersion === 1) {
-  //   console.log('🔄 Upgrading database to version 2...');
-  //   const version2Migrations = getMigrationsByVersion(2);
-  //
-  //   for (const migration of version2Migrations) {
-  //     executeMigration(db, migration);
-  //   }
-  //
-  //   currentDbVersion = 2;
-  //   console.log('✅ Database upgraded to version 2');
-  // }
+  if (currentDbVersion === 1) {
+    console.log("🔄 Upgrading database to version 2...");
+    const version2Migrations = getMigrationsByVersion(2);
+
+    for (const migration of version2Migrations) {
+      console.log(`Executing migration: ${migration.name}`);
+      executeMigration(db, migration);
+    }
+
+    currentDbVersion = 2;
+    console.log("✅ Database upgraded to version 2");
+  }
 
   db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
   return db;

--- a/app/database/migrations/005_create_tickets_table.ts
+++ b/app/database/migrations/005_create_tickets_table.ts
@@ -1,0 +1,42 @@
+// Ticket table migration
+/**
+ * id
+ * ticketNumber (unique)
+ * customerId (FK)
+ * messageId (FK)
+ * status ENUM('pending','replied','resolved') DEFAULT 'pending'
+ * lastMessageAt
+ * unreadCount
+ * createdAt
+ * updatedAt
+ * resolvedAt (nullable)
+ * resolvedBy (FK to users, nullable)
+ *
+ * Indexes on (resolvedAt, lastMessageAt DESC) and (customerId) for fast queries.
+ *
+ */
+export const ticketMigration = `
+-- Ticket table migration
+CREATE TABLE tickets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticketNumber TEXT UNIQUE NOT NULL,
+    customerId INTEGER NOT NULL,
+    messageId INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    lastMessageAt TEXT NOT NULL DEFAULT (datetime('now')),
+    unreadCount INTEGER NOT NULL DEFAULT 0,
+    createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+    updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+    resolvedAt TEXT NULL,
+    resolvedBy INTEGER NULL,
+    FOREIGN KEY (customerId) REFERENCES customers(id) ON DELETE CASCADE,
+    FOREIGN KEY (messageId) REFERENCES messages(id) ON DELETE CASCADE,
+    FOREIGN KEY (resolvedBy) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_tickets_resolvedAt_lastMessageAt ON tickets(resolvedAt, lastMessageAt DESC);
+CREATE INDEX idx_tickets_customerId ON tickets(customerId);
+CREATE INDEX idx_tickets_status ON tickets(status);
+CREATE INDEX idx_tickets_ticketNumber ON tickets(ticketNumber);
+`;

--- a/app/database/migrations/005_create_tickets_table.ts
+++ b/app/database/migrations/005_create_tickets_table.ts
@@ -1,20 +1,4 @@
 // Ticket table migration
-/**
- * id
- * ticketNumber (unique)
- * customerId (FK)
- * messageId (FK)
- * status ENUM('pending','replied','resolved') DEFAULT 'pending'
- * lastMessageAt
- * unreadCount
- * createdAt
- * updatedAt
- * resolvedAt (nullable)
- * resolvedBy (FK to users, nullable)
- *
- * Indexes on (resolvedAt, lastMessageAt DESC) and (customerId) for fast queries.
- *
- */
 export const ticketMigration = `
 -- Ticket table migration
 CREATE TABLE tickets (
@@ -23,7 +7,6 @@ CREATE TABLE tickets (
     customerId INTEGER NOT NULL,
     messageId INTEGER NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
-    lastMessageAt TEXT NOT NULL DEFAULT (datetime('now')),
     unreadCount INTEGER NOT NULL DEFAULT 0,
     createdAt TEXT NOT NULL DEFAULT (datetime('now')),
     updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
@@ -35,7 +18,6 @@ CREATE TABLE tickets (
 );
 
 -- Create indexes for better query performance
-CREATE INDEX idx_tickets_resolvedAt_lastMessageAt ON tickets(resolvedAt, lastMessageAt DESC);
 CREATE INDEX idx_tickets_customerId ON tickets(customerId);
 CREATE INDEX idx_tickets_status ON tickets(status);
 CREATE INDEX idx_tickets_ticketNumber ON tickets(ticketNumber);

--- a/app/database/migrations/005_create_tickets_table.ts
+++ b/app/database/migrations/005_create_tickets_table.ts
@@ -12,7 +12,7 @@ CREATE TABLE tickets (
     updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
     resolvedAt TEXT NULL,
     resolvedBy INTEGER NULL,
-    FOREIGN KEY (customerId) REFERENCES customers(id) ON DELETE CASCADE,
+    FOREIGN KEY (customerId) REFERENCES customer_users(id) ON DELETE CASCADE,
     FOREIGN KEY (messageId) REFERENCES messages(id) ON DELETE CASCADE,
     FOREIGN KEY (resolvedBy) REFERENCES users(id) ON DELETE SET NULL
 );

--- a/app/database/migrations/index.ts
+++ b/app/database/migrations/index.ts
@@ -1,14 +1,8 @@
-// Migration exports for easy importing
-export { usersMigration } from "./001_create_users_table";
-export { customerUsersMigration } from "./002_create_customer_users_table";
-export { messagesMigration } from "./003_create_messages_table";
-export { profileMigration } from "./004_create_profile_table";
-
-// Import the migrations for the array
 import { usersMigration } from "./001_create_users_table";
 import { customerUsersMigration } from "./002_create_customer_users_table";
 import { messagesMigration } from "./003_create_messages_table";
 import { profileMigration } from "./004_create_profile_table";
+import { ticketMigration } from "./005_create_tickets_table";
 
 // Type definition for migration objects
 export interface Migration {
@@ -24,6 +18,7 @@ export const allMigrations: Migration[] = [
   { version: 1, name: "customer_users", migration: customerUsersMigration },
   { version: 1, name: "messages", migration: messagesMigration },
   { version: 1, name: "profile", migration: profileMigration },
+  { version: 2, name: "tickets", migration: ticketMigration },
 
   // Future version 2 migrations can be added here
   // { version: 2, name: 'some_new_table', migration: someNewTableMigration },

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -8,6 +8,7 @@ module.exports = defineConfig([
     ignores: ["dist/*"],
     rules: {
       "react/react-in-jsx-scope": "off",
+      "curly": ["error", "all"],
     },
   },
 ]);

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -130,7 +130,6 @@ class ApiClient {
       tickets: res.tickets.map((ticket: any) => ({
         ...ticket,
         ticketNumber: ticket.ticket_number,
-        lastMessageAt: ticket.last_message_at,
         unreadCount: ticket.resolved_at ? 0 : 1,
       })),
     };

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -71,6 +71,37 @@ class ApiClient {
 
     return response.json();
   }
+
+  async getTickets(
+    token: string,
+    status: "open" | "resolved",
+    page: number = 1,
+    size?: number
+  ): Promise<any> {
+    const sizeQuery = size ? `&size=${size}` : "";
+    const response = await fetch(
+      `${this.baseUrl}/tickets/?status=${status}&page=${page}${sizeQuery}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    // console.log(`Fetching tickets: status=${status}, page=${page}${sizeQuery}`, await response.json());
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch tickets");
+    }
+
+    const res = await response.json();
+    return {
+      ...res,
+      tickets: res.tickets.map((ticket: any) => ({
+        ...ticket,
+        ticketNumber: ticket.ticket_number, // map ticket_number to ticketNumber
+      })),
+    };
+  }
 }
 
 export const api = new ApiClient();

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -34,9 +34,14 @@ interface TokenResponse {
 
 class ApiClient {
   private baseUrl: string;
+  private unauthorizedHandler?: () => void;
 
   constructor(baseUrl: string = API_BASE_URL) {
     this.baseUrl = baseUrl;
+  }
+
+  setUnauthorizedHandler(handler?: () => void) {
+    this.unauthorizedHandler = handler;
   }
 
   async login(credentials: LoginCredentials): Promise<TokenResponse> {
@@ -49,6 +54,18 @@ class ApiClient {
     });
 
     if (!response.ok) {
+      if (response.status === 401) {
+        // trigger registered unauthorized handler and throw
+        if (this.unauthorizedHandler) {
+          try {
+            this.unauthorizedHandler();
+          } catch (e) {
+            // swallow handler errors
+            console.error("unauthorizedHandler error:", e);
+          }
+        }
+      }
+
       const error = await response
         .json()
         .catch(() => ({ detail: "Login failed" }));
@@ -76,7 +93,7 @@ class ApiClient {
     token: string,
     status: "open" | "resolved",
     page: number = 1,
-    size?: number
+    size?: number,
   ): Promise<any> {
     const sizeQuery = size ? `&size=${size}` : "";
     const response = await fetch(
@@ -85,12 +102,26 @@ class ApiClient {
         headers: {
           Authorization: `Bearer ${token}`,
         },
-      }
+      },
     );
-    // console.log(`Fetching tickets: status=${status}, page=${page}${sizeQuery}`, await response.json());
 
     if (!response.ok) {
-      throw new Error("Failed to fetch tickets");
+      if (response.status === 401) {
+        if (this.unauthorizedHandler) {
+          try {
+            this.unauthorizedHandler();
+          } catch (e) {
+            console.error("unauthorizedHandler error:", e);
+          }
+        }
+      }
+      // return HTTP status code and error message
+      const error = await response
+        .json()
+        .catch(() => ({ detail: "Failed to fetch tickets" }));
+      throw new Error(
+        `${response.status}: ${error.detail || "Failed to fetch tickets"}`,
+      );
     }
 
     const res = await response.json();
@@ -99,6 +130,8 @@ class ApiClient {
       tickets: res.tickets.map((ticket: any) => ({
         ...ticket,
         ticketNumber: ticket.ticket_number, // map ticket_number to ticketNumber
+        lastMessageAt: ticket.last_message_at,
+        unreadCount: 1,
       })),
     };
   }

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -135,6 +135,37 @@ class ApiClient {
       })),
     };
   }
+
+  async closeTicket(token: string, ticketID: number): Promise<any> {
+    const response = await fetch(`${this.baseUrl}/tickets/${ticketID}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        resolved_at: new Date().toISOString().replace("Z", "+00:00"),
+      }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        if (this.unauthorizedHandler) {
+          try {
+            this.unauthorizedHandler();
+          } catch (e) {
+            console.error("unauthorizedHandler error:", e);
+          }
+        }
+      }
+      const error = await response
+        .json()
+        .catch(() => ({ detail: "Failed to close ticket" }));
+      throw new Error(error.detail || "Failed to close ticket");
+    }
+
+    return response.json();
+  }
 }
 
 export const api = new ApiClient();

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -129,9 +129,9 @@ class ApiClient {
       ...res,
       tickets: res.tickets.map((ticket: any) => ({
         ...ticket,
-        ticketNumber: ticket.ticket_number, // map ticket_number to ticketNumber
+        ticketNumber: ticket.ticket_number,
         lastMessageAt: ticket.last_message_at,
-        unreadCount: 1,
+        unreadCount: ticket.resolved_at ? 0 : 1,
       })),
     };
   }

--- a/app/services/ticketSync.ts
+++ b/app/services/ticketSync.ts
@@ -286,7 +286,6 @@ class TicketSyncService {
         resolvedAt: ticketData.resolvedAt || ticketData.resolved_at,
         resolvedBy: ticketData?.resolver?.id || null,
         unreadCount: ticketData.unreadCount || ticketData.unread_count || 0,
-        lastMessageAt: ticketData.lastMessageAt || ticketData.last_message_at,
       });
     } catch (error) {
       console.error("Error syncing ticket:", error);

--- a/app/services/ticketSync.ts
+++ b/app/services/ticketSync.ts
@@ -3,8 +3,6 @@ import { api } from "./api";
 import { DAOManager } from "@/database/dao";
 import { Ticket } from "@/database/dao/types/ticket";
 
-const dao = DAOManager.getInstance();
-
 interface SyncResult {
   tickets: Ticket[];
   total: number;
@@ -33,6 +31,9 @@ class TicketSyncService {
     userId?: number,
   ): Promise<SyncResult> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       // Always try local first for initial page
       const localResult = dao.ticket.findByStatus(db, status, page, pageSize);
 
@@ -71,6 +72,7 @@ class TicketSyncService {
     } catch (error) {
       console.error("Error getting tickets:", error);
       // On error, try to return local data as fallback
+      const dao = new DAOManager(db);
       const localResult = dao.ticket.findByStatus(db, status, page, pageSize);
       return {
         ...localResult,
@@ -91,6 +93,9 @@ class TicketSyncService {
     userId?: number,
   ): Promise<SyncResult> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       // Fetch from API
       const apiData = await api.getTickets(accessToken, status, page, pageSize);
       const apiTickets = apiData?.tickets || [];
@@ -126,6 +131,9 @@ class TicketSyncService {
     userId?: number,
   ): Promise<void> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       for (const apiTicket of apiTickets) {
         // 1. Sync customer
         let customerId: number | null = null;
@@ -196,6 +204,9 @@ class TicketSyncService {
     customerData: any,
   ): Promise<number> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       // Check if customer exists by ID first (API customer ID)
       let existing = null;
 
@@ -243,6 +254,9 @@ class TicketSyncService {
     messageData: any,
   ): Promise<number> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       // Try to find existing message by message_sid if available
       let existing = null;
 
@@ -286,6 +300,9 @@ class TicketSyncService {
     ticketData: any,
   ): Promise<void> {
     try {
+      // Create DAO manager instance
+      const dao = new DAOManager(db);
+
       // Ensure resolvedAt is explicitly null for open tickets
       const resolvedAt =
         ticketData.resolvedAt || ticketData.resolved_at || null;

--- a/app/services/ticketSync.ts
+++ b/app/services/ticketSync.ts
@@ -261,6 +261,7 @@ class TicketSyncService {
   ): Promise<void> {
     try {
       dao.ticket.upsert(db, {
+        id: ticketData.id, // Include API id
         ticketNumber: ticketData.ticketNumber || ticketData.ticket_number,
         customerId: ticketData.customerId,
         messageId: ticketData.messageId,

--- a/app/services/ticketSync.ts
+++ b/app/services/ticketSync.ts
@@ -1,0 +1,393 @@
+import { SQLiteDatabase } from "expo-sqlite";
+import { api } from "./api";
+import { DAOManager } from "@/database/dao";
+import { Ticket } from "@/database/dao/types/ticket";
+
+const dao = DAOManager.getInstance();
+
+interface SyncResult {
+  tickets: Ticket[];
+  total: number;
+  page: number;
+  size: number;
+  source: "local" | "api" | "hybrid";
+}
+
+/**
+ * Ticket Sync Service
+ * Handles fetching tickets from SQLite and syncing with the API
+ */
+class TicketSyncService {
+  /**
+   * Get tickets with local-first approach
+   * 1. First try to load from local SQLite
+   * 2. If empty, fetch from API and save to SQLite
+   * 3. If not empty but loading next page, fetch from API and sync
+   */
+  static async getTickets(
+    db: SQLiteDatabase,
+    accessToken: string,
+    status: "open" | "resolved",
+    page: number = 1,
+    pageSize: number = 10,
+    userId?: number,
+  ): Promise<SyncResult> {
+    try {
+      // Always try local first for initial page
+      const localResult = dao.ticket.findByStatus(db, status, page, pageSize);
+
+      // If we have local data for page 1, return it and sync in background
+      if (page === 1 && localResult.tickets.length > 0) {
+        // Return local data immediately
+        const result: SyncResult = {
+          ...localResult,
+          source: "local",
+        };
+
+        // Sync in background (don't await)
+        this.syncFromAPI(db, accessToken, status, page, pageSize, userId).catch(
+          (err) => {
+            console.error("Background sync failed:", err);
+          },
+        );
+
+        return result;
+      }
+
+      // If no local data or loading next page, fetch from API
+      const apiResult = await this.syncFromAPI(
+        db,
+        accessToken,
+        status,
+        page,
+        pageSize,
+        userId,
+      );
+
+      return {
+        ...apiResult,
+        source: page === 1 ? "api" : "hybrid",
+      };
+    } catch (error) {
+      console.error("Error getting tickets:", error);
+      // On error, try to return local data as fallback
+      const localResult = dao.ticket.findByStatus(db, status, page, pageSize);
+      return {
+        ...localResult,
+        source: "local",
+      };
+    }
+  }
+
+  /**
+   * Sync tickets from API and save to SQLite
+   */
+  static async syncFromAPI(
+    db: SQLiteDatabase,
+    accessToken: string,
+    status: "open" | "resolved",
+    page: number = 1,
+    pageSize: number = 10,
+    userId?: number,
+  ): Promise<SyncResult> {
+    try {
+      // Fetch from API
+      const apiData = await api.getTickets(accessToken, status, page, pageSize);
+      const apiTickets = apiData?.tickets || [];
+
+      // Sync each ticket to local database
+      if (apiTickets.length > 0) {
+        await this.syncTicketsToLocal(db, apiTickets, userId);
+      }
+
+      // Return fresh data from local database to ensure consistency
+      const localResult = dao.ticket.findByStatus(db, status, page, pageSize);
+
+      return {
+        tickets: localResult.tickets,
+        total: apiData?.total ?? localResult.total,
+        page: apiData?.page ?? page,
+        size: apiData?.size ?? pageSize,
+        source: "api",
+      };
+    } catch (error) {
+      console.error("Error syncing from API:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Sync API tickets to local database
+   * Handles creating/updating customers, messages, and tickets
+   */
+  private static async syncTicketsToLocal(
+    db: SQLiteDatabase,
+    apiTickets: any[],
+    userId?: number,
+  ): Promise<void> {
+    try {
+      for (const apiTicket of apiTickets) {
+        // 1. Sync customer
+        let customerId: number | null = null;
+        if (apiTicket.customer) {
+          customerId = await this.syncCustomer(db, apiTicket.customer);
+        } else if (apiTicket.customer_id) {
+          // Handle case where only customer_id is provided
+          customerId = apiTicket.customer_id;
+        }
+
+        // 2. Sync initial message if available
+        let messageId: number | null = null;
+        if (apiTicket.message) {
+          messageId = await this.syncMessage(db, {
+            ...apiTicket.message,
+            customer_id: customerId,
+            user_id: userId || null,
+          });
+        } else if (apiTicket.message_id) {
+          // Handle case where only message_id is provided
+          messageId = apiTicket.message_id;
+        }
+
+        // 3. Sync ticket - even if customer/message are missing
+        // This ensures we don't lose ticket data
+        if (customerId && messageId) {
+          await this.syncTicket(db, {
+            ...apiTicket,
+            customerId,
+            messageId,
+          });
+        } else {
+          console.warn(
+            `Skipping ticket ${apiTicket.ticketNumber || apiTicket.ticket_number}: missing customer or message`,
+          );
+        }
+      }
+    } catch (error) {
+      console.error("Error syncing tickets to local:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Sync a single customer to local database
+   */
+  private static async syncCustomer(
+    db: SQLiteDatabase,
+    customerData: any,
+  ): Promise<number> {
+    try {
+      // Check if customer exists by phone number or id
+      let existing = null;
+
+      if (customerData.phone_number) {
+        existing = dao.customerUser.findByPhoneNumber(
+          db,
+          customerData.phone_number,
+        );
+      }
+
+      if (existing) {
+        // Update if needed
+        dao.customerUser.update(db, existing.id, {
+          fullName: customerData.name || customerData.full_name,
+          phoneNumber: customerData.phone_number,
+        });
+        return existing.id;
+      } else {
+        // Create new customer
+        const created = dao.customerUser.create(db, {
+          phoneNumber: customerData.phone_number || `unknown_${Date.now()}`,
+          fullName: customerData.name || customerData.full_name || "Unknown",
+          language: customerData.language || "en",
+        });
+        return created.id;
+      }
+    } catch (error) {
+      console.error("Error syncing customer:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Sync a single message to local database
+   */
+  private static async syncMessage(
+    db: SQLiteDatabase,
+    messageData: any,
+  ): Promise<number> {
+    try {
+      // Try to find existing message by message_sid if available
+      let existing = null;
+
+      if (messageData.message_sid) {
+        const stmt = db.prepareSync(
+          "SELECT * FROM messages WHERE message_sid = ? LIMIT 1",
+        );
+        try {
+          const result = stmt.executeSync<any>([messageData.message_sid]);
+          existing = result.getFirstSync();
+        } finally {
+          stmt.finalizeSync();
+        }
+      }
+
+      if (existing) {
+        return existing.id;
+      } else {
+        // Create new message
+        const created = dao.message.create(db, {
+          from_source: messageData.from_source || "whatsapp",
+          message_sid: messageData.message_sid || `msg_${Date.now()}`,
+          customer_id: messageData.customer_id,
+          user_id: messageData.user_id || null,
+          body: messageData.body || messageData.content || "",
+          message_type: messageData.message_type || "text",
+        });
+        return created.id;
+      }
+    } catch (error) {
+      console.error("Error syncing message:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Sync a single ticket to local database
+   */
+  private static async syncTicket(
+    db: SQLiteDatabase,
+    ticketData: any,
+  ): Promise<void> {
+    try {
+      dao.ticket.upsert(db, {
+        ticketNumber: ticketData.ticketNumber || ticketData.ticket_number,
+        customerId: ticketData.customerId,
+        messageId: ticketData.messageId,
+        status: ticketData.status,
+        resolvedAt: ticketData.resolvedAt || ticketData.resolved_at,
+        unreadCount: ticketData.unreadCount || ticketData.unread_count || 0,
+        lastMessageAt: ticketData.lastMessageAt || ticketData.last_message_at,
+      });
+    } catch (error) {
+      console.error("Error syncing ticket:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Force refresh all tickets for a given status
+   * Clears local cache and fetches fresh from API
+   */
+  static async forceRefresh(
+    db: SQLiteDatabase,
+    accessToken: string,
+    status: "open" | "resolved",
+    userId?: number,
+  ): Promise<SyncResult> {
+    try {
+      // Fetch first page from API
+      const result = await this.syncFromAPI(
+        db,
+        accessToken,
+        status,
+        1,
+        10,
+        userId,
+      );
+      return result;
+    } catch (error) {
+      console.error("Error force refreshing tickets:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get sync statistics for debugging
+   */
+  static getSyncStats(db: SQLiteDatabase): {
+    totalTickets: number;
+    openTickets: number;
+    resolvedTickets: number;
+    totalCustomers: number;
+    totalMessages: number;
+  } {
+    try {
+      const ticketsStmt = db.prepareSync(
+        "SELECT COUNT(*) as count FROM tickets",
+      );
+      const openStmt = db.prepareSync(
+        "SELECT COUNT(*) as count FROM tickets WHERE resolvedAt IS NULL",
+      );
+      const resolvedStmt = db.prepareSync(
+        "SELECT COUNT(*) as count FROM tickets WHERE resolvedAt IS NOT NULL",
+      );
+      const customersStmt = db.prepareSync(
+        "SELECT COUNT(*) as count FROM customer_users",
+      );
+      const messagesStmt = db.prepareSync(
+        "SELECT COUNT(*) as count FROM messages",
+      );
+
+      const totalTickets =
+        ticketsStmt.executeSync<{ count: number }>().getFirstSync()?.count || 0;
+      const openTickets =
+        openStmt.executeSync<{ count: number }>().getFirstSync()?.count || 0;
+      const resolvedTickets =
+        resolvedStmt.executeSync<{ count: number }>().getFirstSync()?.count ||
+        0;
+      const totalCustomers =
+        customersStmt.executeSync<{ count: number }>().getFirstSync()?.count ||
+        0;
+      const totalMessages =
+        messagesStmt.executeSync<{ count: number }>().getFirstSync()?.count ||
+        0;
+
+      ticketsStmt.finalizeSync();
+      openStmt.finalizeSync();
+      resolvedStmt.finalizeSync();
+      customersStmt.finalizeSync();
+      messagesStmt.finalizeSync();
+
+      return {
+        totalTickets,
+        openTickets,
+        resolvedTickets,
+        totalCustomers,
+        totalMessages,
+      };
+    } catch (error) {
+      console.error("Error getting sync stats:", error);
+      return {
+        totalTickets: 0,
+        openTickets: 0,
+        resolvedTickets: 0,
+        totalCustomers: 0,
+        totalMessages: 0,
+      };
+    }
+  }
+
+  /**
+   * Clear all cached tickets (use with caution)
+   */
+  static clearCache(db: SQLiteDatabase): boolean {
+    try {
+      db.execSync("BEGIN TRANSACTION");
+      db.execSync("DELETE FROM tickets");
+      db.execSync("COMMIT");
+      console.log("✅ Cache cleared successfully");
+      return true;
+    } catch (error) {
+      console.error("Error clearing cache:", error);
+      try {
+        db.execSync("ROLLBACK");
+      } catch (rollbackError) {
+        console.error("Error rolling back:", rollbackError);
+      }
+      return false;
+    }
+  }
+}
+
+export default TicketSyncService;

--- a/app/utils/chat.ts
+++ b/app/utils/chat.ts
@@ -2,7 +2,7 @@ export interface Message {
   id: number;
   name: string; // sender's name
   text: string;
-  sender: "user" | "agent";
+  sender: "user" | "customer";
   timestamp: string; // ISO string or formatted date
 }
 
@@ -56,11 +56,11 @@ const generateDummyMessages = (count = 100): Message[] => {
     dt.setMinutes(dt.getMinutes() - minuteOffset);
     msgs.push({
       id: id++,
-      name: isUser ? "You" : "Support Agent",
+      name: isUser ? "You" : "Customer",
       text: isUser
         ? `User message #${id - 1} — sample text to simulate chat content.`
-        : `Agent message #${id - 1} — assisting the user with a response.`,
-      sender: isUser ? "user" : "agent",
+        : `Customer message #${id - 1} — ask question.`,
+      sender: isUser ? "user" : "customer",
       timestamp: dt.toLocaleString(),
     });
   }

--- a/app/utils/chat.ts
+++ b/app/utils/chat.ts
@@ -1,0 +1,103 @@
+export interface Message {
+  id: number;
+  name: string; // sender's name
+  text: string;
+  sender: "user" | "agent";
+  timestamp: string; // ISO string or formatted date
+}
+
+const groupMessagesByDate = (messages: Message[]) => {
+  const groups: { [key: string]: Message[] } = {};
+  messages.forEach((m) => {
+    const dt = new Date(m.timestamp);
+    const key = isNaN(dt.getTime())
+      ? m.timestamp.split(" ")[0]
+      : dt.toDateString();
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(m);
+  });
+
+  // Sort the date keys chronologically and sort messages within each group by timestamp
+  // This ensures new messages appear in the correct chronological order
+  return Object.keys(groups)
+    .sort((a, b) => {
+      const dateA = new Date(a);
+      const dateB = new Date(b);
+      // Handle invalid dates by treating them as strings
+      if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
+        return a.localeCompare(b);
+      }
+      return dateA.getTime() - dateB.getTime();
+    })
+    .map((k) => ({
+      date: k,
+      items: groups[k].sort((a, b) => {
+        const timeA = new Date(a.timestamp);
+        const timeB = new Date(b.timestamp);
+        // Handle invalid timestamps by using ID as fallback
+        if (isNaN(timeA.getTime()) || isNaN(timeB.getTime())) {
+          return a.id - b.id;
+        }
+        return timeA.getTime() - timeB.getTime();
+      }),
+    }));
+};
+
+const generateDummyMessages = (count = 100): Message[] => {
+  const msgs: Message[] = [];
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth();
+
+  // helper to push a message for a given date and minute offset
+  let id = 1;
+  function pushMsg(dayOffset: number, minuteOffset: number, isUser: boolean) {
+    const dt = new Date(currentYear, currentMonth, today.getDate() - dayOffset);
+    dt.setMinutes(dt.getMinutes() - minuteOffset);
+    msgs.push({
+      id: id++,
+      name: isUser ? "You" : "Support Agent",
+      text: isUser
+        ? `User message #${id - 1} — sample text to simulate chat content.`
+        : `Agent message #${id - 1} — assisting the user with a response.`,
+      sender: isUser ? "user" : "agent",
+      timestamp: dt.toLocaleString(),
+    });
+  }
+
+  // Create messages for: today (30 msgs), yesterday (30 msgs), and previous days within current month (remaining)
+  const todayCount = Math.min(30, count);
+  const yesterdayCount = Math.min(30, Math.max(0, count - todayCount));
+  const remaining = Math.max(0, count - todayCount - yesterdayCount);
+
+  // today messages
+  for (let i = 0; i < todayCount; i++) {
+    pushMsg(0, i * 5, i % 2 === 0);
+  }
+
+  // yesterday messages
+  for (let i = 0; i < yesterdayCount; i++) {
+    pushMsg(1, i * 7, i % 2 === 0);
+  }
+
+  // distribute remaining across previous days of the month (starting 2 days ago)
+  let day = 2;
+  let placed = 0;
+  while (placed < remaining) {
+    const perDay = 6; // up to 6 messages per older day
+    for (let i = 0; i < perDay && placed < remaining; i++) {
+      pushMsg(day, i * 10, placed % 2 === 0);
+      placed++;
+    }
+    day++;
+    // stop if we reach beginning of month
+    if (day > 28) break;
+  }
+
+  return msgs;
+};
+
+export default {
+  groupMessagesByDate,
+  generateDummyMessages,
+};

--- a/app/utils/string.ts
+++ b/app/utils/string.ts
@@ -1,0 +1,10 @@
+export const initialsFromName = (name: string) =>
+  name
+    .split(" ")
+    .map((n) => n.charAt(0).toUpperCase())
+    .slice(0, 2)
+    .join("");
+
+export default {
+  initialsFromName,
+};

--- a/app/utils/time.ts
+++ b/app/utils/time.ts
@@ -1,0 +1,44 @@
+export const formatTime = (iso?: string) => {
+  if (!iso) return "";
+  const d = new Date(iso);
+  let hours = d.getHours();
+  const minutes = d.getMinutes();
+  const ampm = hours >= 12 ? "PM" : "AM";
+  hours = hours % 12 || 12;
+  const mm = minutes < 10 ? `0${minutes}` : String(minutes);
+  return `${hours}:${mm} ${ampm}`;
+};
+
+export const relativeDays = (iso: string) => {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+};
+
+export const formatResolved = (iso?: string | null) => {
+  if (!iso) return null;
+  const diffDays = relativeDays(iso as string);
+  const timeStr = formatTime(iso as string);
+  if (diffDays === 0) return `Today at ${timeStr}`;
+  if (diffDays === 1) return `Yesterday at ${timeStr}`;
+  return `${diffDays} days ago`;
+};
+
+export const formatDateLabel = (rawDate: string) => {
+  // rawDate is from toDateString() or a fallback string; try to create Date
+  const dt = new Date(rawDate);
+  if (!isNaN(dt.getTime())) {
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+    if (dt.toDateString() === today.toDateString()) return "Today";
+    if (dt.toDateString() === yesterday.toDateString()) return "Yesterday";
+    // format dd/mm/yyyy
+    const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+    return `${pad2(dt.getDate())}/${pad2(
+      dt.getMonth() + 1
+    )}/${dt.getFullYear()}`;
+  }
+  return rawDate;
+};

--- a/app/utils/time.ts
+++ b/app/utils/time.ts
@@ -37,7 +37,7 @@ export const formatDateLabel = (rawDate: string) => {
     // format dd/mm/yyyy
     const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`);
     return `${pad2(dt.getDate())}/${pad2(
-      dt.getMonth() + 1
+      dt.getMonth() + 1,
     )}/${dt.getFullYear()}`;
   }
   return rawDate;

--- a/backend/alembic/versions/2025_10_03_0908-91ada8ea599b_add_tickets_table.py
+++ b/backend/alembic/versions/2025_10_03_0908-91ada8ea599b_add_tickets_table.py
@@ -28,7 +28,6 @@ def upgrade() -> None:
         sa.Column('customer_id', sa.Integer(), nullable=False),
         sa.Column('message_id', sa.Integer(), nullable=False),
         sa.Column('resolved_by', sa.Integer(), nullable=True),
-        sa.Column('last_message_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('resolved_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
         sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),

--- a/backend/alembic/versions/2025_10_03_0908-91ada8ea599b_add_tickets_table.py
+++ b/backend/alembic/versions/2025_10_03_0908-91ada8ea599b_add_tickets_table.py
@@ -1,0 +1,55 @@
+"""add_tickets_table
+
+Revision ID: 91ada8ea599b
+Revises: ed5e11c3b7f7
+Create Date: 2025-10-03 09:08:16.502882
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '91ada8ea599b'
+down_revision: Union[str, None] = 'ed5e11c3b7f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create tickets table
+    op.create_table(
+        'tickets',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ticket_number', sa.String(length=50), nullable=False),
+        sa.Column('administrative_id', sa.Integer(), nullable=False),
+        sa.Column('customer_id', sa.Integer(), nullable=False),
+        sa.Column('message_id', sa.Integer(), nullable=False),
+        sa.Column('resolved_by', sa.Integer(), nullable=True),
+        sa.Column('last_message_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('resolved_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['administrative_id'], ['administrative.id'], ),
+        sa.ForeignKeyConstraint(['customer_id'], ['customers.id'], ),
+        sa.ForeignKeyConstraint(['message_id'], ['messages.id'], ),
+        sa.ForeignKeyConstraint(['resolved_by'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Create indexes
+    op.create_index(op.f('ix_tickets_id'), 'tickets', ['id'], unique=False)
+    op.create_index(op.f('ix_tickets_ticket_number'), 'tickets', ['ticket_number'], unique=True)
+    op.create_index(op.f('ix_tickets_customer_id'), 'tickets', ['customer_id'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index(op.f('ix_tickets_customer_id'), table_name='tickets')
+    op.drop_index(op.f('ix_tickets_ticket_number'), table_name='tickets')
+    op.drop_index(op.f('ix_tickets_id'), table_name='tickets')
+
+    # Drop table
+    op.drop_table('tickets')

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from routers import (
     knowledge_base,
     service_tokens,
     whatsapp,
+    tickets,
 )
 
 app = FastAPI(
@@ -37,6 +38,7 @@ app.include_router(customers.router, prefix="/api")
 app.include_router(knowledge_base.router, prefix="/api")
 app.include_router(service_tokens.router, prefix="/api")
 app.include_router(whatsapp.router, prefix="/api")
+app.include_router(tickets.router, prefix="/api")
 
 
 @app.get("/api/health-check", tags=["health-check"])

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -8,6 +8,7 @@ from .customer import Customer, CustomerLanguage
 from .knowledge_base import KnowledgeBase
 from .message import Message, MessageFrom
 from .service_token import ServiceToken
+from .ticket import Ticket
 from .user import User, UserType
 from database import Base
 
@@ -20,6 +21,7 @@ __all__ = [
     "Message",
     "MessageFrom",
     "ServiceToken",
+    "Ticket",
     "Administrative",
     "AdministrativeLevel",
     "CustomerAdministrative",

--- a/backend/models/administrative.py
+++ b/backend/models/administrative.py
@@ -40,6 +40,7 @@ class Administrative(Base):
     customer_administrative = relationship(
         "CustomerAdministrative", back_populates="administrative"
     )
+    tickets = relationship("Ticket", back_populates="ticket_administrative")
 
 
 class UserAdministrative(Base):

--- a/backend/models/customer.py
+++ b/backend/models/customer.py
@@ -28,3 +28,4 @@ class Customer(Base):
     customer_administrative = relationship(
         "CustomerAdministrative", back_populates="customer"
     )
+    tickets = relationship("Ticket", back_populates="customer")

--- a/backend/models/ticket.py
+++ b/backend/models/ticket.py
@@ -27,7 +27,6 @@ class Ticket(Base):
         Integer, ForeignKey("messages.id"), nullable=False
     )
     resolved_by = Column(Integer, ForeignKey("users.id"), nullable=True)
-    last_message_at = Column(DateTime(timezone=True), nullable=True)
     resolved_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(

--- a/backend/models/ticket.py
+++ b/backend/models/ticket.py
@@ -1,0 +1,42 @@
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from database import Base
+
+
+class Ticket(Base):
+    __tablename__ = "tickets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_number = Column(String(50), unique=True, nullable=False, index=True)
+    administrative_id = Column(
+        Integer,
+        ForeignKey("administrative.id"),
+        nullable=False
+    )
+    customer_id = Column(
+        Integer, ForeignKey("customers.id"), nullable=False, index=True
+    )
+    message_id = Column(
+        Integer, ForeignKey("messages.id"), nullable=False
+    )
+    resolved_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+    last_message_at = Column(DateTime(timezone=True), nullable=True)
+    resolved_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    customer = relationship("Customer", back_populates="tickets")
+    message = relationship("Message")
+    resolver = relationship("User")
+    ticket_administrative = relationship(
+        "Administrative", back_populates="tickets"
+    )

--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -1,0 +1,321 @@
+from typing import Optional, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+from datetime import datetime
+
+from database import get_db
+from models.ticket import Ticket
+from models.customer import Customer
+from models.message import Message
+from models.user import User, UserType
+from models.administrative import UserAdministrative, Administrative
+from schemas.ticket import (
+    TicketCreate,
+    TicketListResponse,
+    TicketResponse,
+    TicketMessagesResponse,
+    TicketStatus,
+)
+from utils.auth_dependencies import get_current_user
+
+router = APIRouter(prefix="/tickets", tags=["tickets"])
+
+
+def _get_user_administrative_ids(user: User, db: Session) -> List[int]:
+    """Get list of administrative IDs accessible by the user."""
+    if user.user_type == UserType.ADMIN:
+        # Admin can access all tickets
+        return []
+
+    # EO can only access tickets in their assigned administrative areas
+    user_admins = (
+        db.query(UserAdministrative)
+        .filter(UserAdministrative.user_id == user.id)
+        .all()
+    )
+
+    return [ua.administrative_id for ua in user_admins]
+
+
+def _check_ticket_access(ticket: Ticket, user: User, db: Session) -> None:
+    """Check if user has access to the ticket. Raises 403 if not."""
+    if user.user_type == UserType.ADMIN:
+        # Admin has access to all tickets
+        return
+
+    # EO can only access tickets in their administrative area
+    admin_ids = _get_user_administrative_ids(user, db)
+    if ticket.administrative_id not in admin_ids:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "You do not have access to tickets"
+                " outside your administrative area"
+            ),
+        )
+
+
+def _serialize_ticket(ticket: Ticket) -> dict:
+    resolver = None
+    if ticket.resolved_by:
+        # lazy load resolver
+        resolver_obj = ticket.resolver
+        resolver = (
+            {"id": resolver_obj.id, "name": resolver_obj.full_name}
+            if resolver_obj
+            else None
+        )
+
+    customer = ticket.customer
+    message = ticket.message
+
+    return {
+        "id": ticket.id,
+        "ticket_number": ticket.ticket_number,
+        "customer": (
+            {"id": customer.id, "name": customer.full_name}
+            if customer
+            else None
+        ),
+        "message": (
+            {"id": message.id, "body": message.body} if message else None
+        ),
+        "status": "resolved" if ticket.resolved_at else "open",
+        "created_at": (
+            ticket.created_at.isoformat() if ticket.created_at else None
+        ),
+        "resolved_at": (
+            ticket.resolved_at.isoformat() if ticket.resolved_at else None
+        ),
+        "resolver": resolver,
+        "last_message_at": (
+            ticket.last_message_at.isoformat()
+            if ticket.last_message_at
+            else None
+        ),
+    }
+
+
+@router.post(
+    "/", response_model=TicketResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_ticket(payload: TicketCreate, db: Session = Depends(get_db)):
+    """Create a ticket (no auth required)."""
+    # Validate customer and message
+    customer = (
+        db.query(Customer).filter(Customer.id == payload.customer_id).first()
+    )
+    if not customer:
+        raise HTTPException(status_code=404, detail="Customer not found")
+
+    message = (
+        db.query(Message).filter(Message.id == payload.message_id).first()
+    )
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    # Ensure message not already ticketed
+    existing = db.query(Ticket).filter(Ticket.message_id == message.id).first()
+    if existing:
+        raise HTTPException(
+            status_code=400, detail="Message already linked to a ticket"
+        )
+
+    # Get administrative_id from Administrative with national level = 1
+    national_adm = (
+        db.query(Administrative.id)
+        .filter(Administrative.parent_id.is_(None))
+        .first()
+    )
+    admin_id = national_adm.id
+    if (
+        hasattr(customer, "customer_administrative")
+        and len(customer.customer_administrative) > 0
+    ):
+        admin_id = customer.customer_administrative[0].administrative_id
+
+    ticket_number = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ticket = Ticket(
+        ticket_number=ticket_number,
+        administrative_id=admin_id,
+        customer_id=customer.id,
+        message_id=message.id,
+        last_message_at=message.created_at,
+    )
+    db.add(ticket)
+    db.commit()
+    db.refresh(ticket)
+
+    return {"ticket": _serialize_ticket(ticket)}
+
+
+@router.get("/", response_model=TicketListResponse)
+async def list_tickets(
+    status: Optional[TicketStatus] = Query(TicketStatus.OPEN),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List tickets with pagination and optional status filter.
+
+    Admin users can see all tickets.
+    EO users can only see tickets in their assigned administrative areas.
+    """
+    query = db.query(Ticket)
+
+    # Filter by administrative area for EO users
+    if current_user.user_type == UserType.EXTENSION_OFFICER:
+        admin_ids = _get_user_administrative_ids(current_user, db)
+        if not admin_ids:
+            # EO has no administrative assignments, return empty
+            return {
+                "tickets": [],
+                "total": 0,
+                "page": page,
+                "size": page_size,
+            }
+        query = query.filter(Ticket.administrative_id.in_(admin_ids))
+
+    # Filter by status
+    if status == TicketStatus.OPEN:
+        query = query.filter(Ticket.resolved_at.is_(None))
+    elif status == TicketStatus.RESOLVED:
+        query = query.filter(Ticket.resolved_at.isnot(None))
+
+    total = query.count()
+    tickets = (
+        query.order_by(Ticket.last_message_at.desc().nulls_last())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return {
+        "tickets": [_serialize_ticket(t) for t in tickets],
+        "total": total,
+        "page": page,
+        "size": page_size,
+    }
+
+
+@router.get("/{ticket_id}", response_model=TicketResponse)
+async def get_ticket_header(
+    ticket_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get ticket header information.
+
+    Admin users can access any ticket.
+    EO users can only access tickets in their assigned administrative areas.
+    """
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Check access for EO users
+    _check_ticket_access(ticket, current_user, db)
+
+    return {"ticket": _serialize_ticket(ticket)}
+
+
+@router.get("/{ticket_id}/messages", response_model=TicketMessagesResponse)
+async def get_ticket_conversation(
+    ticket_id: int,
+    before_ts: Optional[str] = None,
+    limit: int = 10,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get ticket conversation messages.
+
+    Admin users can access any ticket.
+    EO users can only access tickets in their assigned administrative areas.
+    """
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Check access for EO users
+    _check_ticket_access(ticket, current_user, db)
+
+    # get messages for the ticket's customer ordered by created_at desc
+    msgs_query = db.query(Message).filter(
+        Message.customer_id == ticket.customer_id
+    )
+    if before_ts:
+        try:
+            before_dt = datetime.fromisoformat(before_ts)
+            msgs_query = msgs_query.filter(Message.created_at < before_dt)
+        except Exception:
+            # ignore invalid before_ts, return from head
+            pass
+
+    msgs = msgs_query.order_by(Message.created_at.desc()).limit(limit).all()
+
+    messages = [
+        {
+            "id": m.id,
+            "message_sid": m.message_sid,
+            "body": m.body,
+            "from_source": m.from_source,
+            "message_type": (
+                getattr(m, "message_type", None).name
+                if getattr(m, "message_type", None)
+                else None
+            ),
+            "created_at": m.created_at.isoformat() if m.created_at else None,
+        }
+        for m in msgs
+    ]
+
+    return {
+        "messages": messages,
+        "total": len(messages),
+        "before_ts": None,
+        "limit": limit,
+    }
+
+
+@router.patch("/{ticket_id}", response_model=TicketResponse)
+async def mark_ticket_resolved(
+    ticket_id: int,
+    payload: dict,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mark a ticket as resolved.
+
+    Admin users can resolve any ticket.
+    EO users can only resolve tickets in their assigned administrative areas.
+    """
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Check access for EO users
+    _check_ticket_access(ticket, current_user, db)
+
+    if ticket.resolved_at is not None:
+        raise HTTPException(status_code=409, detail="Ticket already resolved")
+
+    resolved_at = payload.get("resolved_at")
+    if not resolved_at:
+        raise HTTPException(status_code=400, detail="resolved_at is required")
+
+    try:
+        resolved_dt = datetime.fromisoformat(resolved_at)
+    except Exception:
+        raise HTTPException(
+            status_code=400, detail="Invalid resolved_at format"
+        )
+
+    ticket.resolved_at = resolved_dt
+    ticket.resolved_by = current_user.id
+    ticket.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(ticket)
+
+    return {"ticket": _serialize_ticket(ticket)}

--- a/backend/schemas/ticket.py
+++ b/backend/schemas/ticket.py
@@ -12,6 +12,7 @@ class TicketStatus(str, Enum):
 class TicketCustomer(BaseModel):
     id: Optional[int]
     name: Optional[str]
+    phone_number: Optional[str]
 
 
 class TicketMessage(BaseModel):

--- a/backend/schemas/ticket.py
+++ b/backend/schemas/ticket.py
@@ -28,7 +28,6 @@ class TicketModel(BaseModel):
     created_at: Optional[datetime]
     resolved_at: Optional[datetime]
     resolver: Optional[Any]
-    last_message_at: Optional[datetime]
 
 
 class TicketCreate(BaseModel):

--- a/backend/schemas/ticket.py
+++ b/backend/schemas/ticket.py
@@ -1,0 +1,54 @@
+from pydantic import BaseModel
+from typing import Optional, List, Any
+from datetime import datetime
+from enum import Enum
+
+
+class TicketStatus(str, Enum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+
+class TicketCustomer(BaseModel):
+    id: Optional[int]
+    name: Optional[str]
+
+
+class TicketMessage(BaseModel):
+    id: Optional[int]
+    body: Optional[str]
+
+
+class TicketModel(BaseModel):
+    id: Optional[int]
+    ticket_number: Optional[str]
+    customer: Optional[TicketCustomer]
+    message: Optional[TicketMessage]
+    status: Optional[str]
+    created_at: Optional[datetime]
+    resolved_at: Optional[datetime]
+    resolver: Optional[Any]
+    last_message_at: Optional[datetime]
+
+
+class TicketCreate(BaseModel):
+    customer_id: int
+    message_id: int
+
+
+class TicketListResponse(BaseModel):
+    tickets: List[TicketModel]
+    total: int
+    page: int
+    size: int
+
+
+class TicketResponse(BaseModel):
+    ticket: TicketModel
+
+
+class TicketMessagesResponse(BaseModel):
+    messages: List[Any]
+    total: int
+    before_ts: Optional[str]
+    limit: int

--- a/backend/seeder/ticket.py
+++ b/backend/seeder/ticket.py
@@ -1,0 +1,219 @@
+"""
+Ticket seeder for creating initial ticket data.
+This module provides functions to seed the database
+with initial ticket data for testing or development purposes.
+"""
+import sys
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime
+import random
+
+from database import SessionLocal, engine
+from models import Base
+from models.ticket import Ticket
+from models.customer import Customer
+from models.message import Message, MessageFrom
+from models.administrative import (
+    Administrative,
+    CustomerAdministrative,
+)
+
+
+def seed_customers(
+    db: Session, administrative: Administrative, total: int = 5
+):
+    """Create or get `total` customers and link them to the
+    given administrative area. Returns list of Customer objects.
+    """
+    customers = []
+    for i in range(total):
+        phone = "+2557" + str(random.randint(10000000, 99999999))
+        full_name = f"Customer {administrative.code}-{i+1}"
+
+        existing = (
+            db.query(Customer)
+            .filter(
+                Customer.phone_number == phone
+            )
+            .first()
+        )
+        if existing:
+            customers.append(existing)
+            continue
+
+        customer = Customer(phone_number=phone, full_name=full_name)
+        db.add(customer)
+        try:
+            db.commit()
+            db.refresh(customer)
+        except IntegrityError:
+            db.rollback()
+            # In case of race/duplicate, fetch existing
+            customer = db.query(Customer).filter(
+                Customer.phone_number == phone
+            ).first()
+            if not customer:
+                continue
+
+        # link to administrative via CustomerAdministrative table
+        try:
+            ca = CustomerAdministrative(
+                customer_id=customer.id,
+                administrative_id=administrative.id,
+            )
+            db.add(ca)
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+
+        customers.append(customer)
+
+    return customers
+
+
+def seed_messages(
+    db: Session, customer: Customer, total: int = 3
+):
+    """Create `total` messages for the given customer.
+
+    Returns list of Message objects.
+    """
+    messages = []
+    for i in range(total):
+        body = (
+            f"Hello from {customer.full_name or customer.phone_number}"
+            f" (msg {i+1})"
+        )
+
+        sid_parts = [
+            "MID",
+            str(customer.id or "new"),
+            str(int(datetime.utcnow().timestamp())),
+            str(i),
+            str(random.randint(100, 999)),
+        ]
+        message_sid = "-".join(sid_parts)
+
+        msg = Message(
+            message_sid=message_sid,
+            customer_id=customer.id,
+            user_id=None,
+            body=body,
+            from_source=(
+                MessageFrom.CUSTOMER if i == 0 else MessageFrom.USER
+            ),
+        )
+
+        db.add(msg)
+        try:
+            db.commit()
+            db.refresh(msg)
+            messages.append(msg)
+        except IntegrityError:
+            db.rollback()
+            existing = (
+                db.query(Message)
+                .filter(Message.message_sid == message_sid)
+                .first()
+            )
+            if existing:
+                messages.append(existing)
+
+    return messages
+
+
+def seed_tickets(
+    db: Session,
+    administrative: Administrative,
+    customer: Customer,
+    initial_message: Message,
+):
+    """Create a ticket for the customer under the administrative area
+    using the initial message.
+    """
+    now = datetime.utcnow()
+    ticket_number = (
+        f"TKT-{administrative.code}-{customer.id}-"
+        f"{int(now.timestamp())}-{random.randint(100, 999)}"
+    )
+
+    ticket = Ticket(
+        ticket_number=ticket_number,
+        administrative_id=administrative.id,
+        customer_id=customer.id,
+        message_id=initial_message.id,
+        last_message_at=initial_message.created_at,
+    )
+
+    db.add(ticket)
+    try:
+        db.commit()
+        db.refresh(ticket)
+        return ticket
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(Ticket)
+            .filter(Ticket.ticket_number == ticket_number)
+            .first()
+        )
+        return existing
+
+
+def main():
+    """Main function for ticket seeder"""
+    try:
+        # Ensure database tables exist
+        Base.metadata.create_all(bind=engine)
+
+        db = SessionLocal()
+
+        # Find administrative areas that have users (areas with at least
+        # one user assigned)
+        administrative_list = (
+            db.query(Administrative)
+            .join(Administrative.user_administrative)
+            .all()
+        )
+        if not administrative_list:
+            print(
+                "❌ No administrative areas with users found. Please "
+                "seed administrative and user data first."
+            )
+            sys.exit(1)
+            sys.exit(1)
+
+        total_tickets_created = 0
+
+        for administrative in administrative_list:
+            # create customers for this administrative
+            customers = seed_customers(
+                db, administrative=administrative, total=5
+            )
+            for customer in customers:
+                messages = seed_messages(db, customer=customer, total=3)
+                if not messages:
+                    continue
+                # first message creates the ticket
+                ticket = seed_tickets(
+                    db,
+                    administrative=administrative,
+                    customer=customer,
+                    initial_message=messages[0],
+                )
+                if ticket:
+                    total_tickets_created += 1
+
+        print(
+            f"✅ Ticket seeding completed successfully. Tickets created: "
+            f"{total_tickets_created}"
+        )
+
+    except Exception as e:
+        print(f"❌ An error occurred: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/seeder/ticket.py
+++ b/backend/seeder/ticket.py
@@ -140,7 +140,6 @@ def seed_tickets(
         administrative_id=administrative.id,
         customer_id=customer.id,
         message_id=initial_message.id,
-        last_message_at=initial_message.created_at,
     )
 
     db.add(ticket)

--- a/backend/seeder/ticket.py
+++ b/backend/seeder/ticket.py
@@ -6,7 +6,7 @@ with initial ticket data for testing or development purposes.
 import sys
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
-from datetime import datetime
+from datetime import datetime, timezone
 import random
 
 from database import SessionLocal, engine
@@ -132,11 +132,8 @@ def seed_tickets(
     """Create a ticket for the customer under the administrative area
     using the initial message.
     """
-    now = datetime.utcnow()
-    ticket_number = (
-        f"TKT-{administrative.code}-{customer.id}-"
-        f"{int(now.timestamp())}-{random.randint(100, 999)}"
-    )
+    now = datetime.now(timezone.utc)
+    ticket_number = now.strftime("%Y%m%d%H%M%S")
 
     ticket = Ticket(
         ticket_number=ticket_number,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -50,9 +50,13 @@ def db_session(test_db):
             UserAdministrative,
         )
 
+        # Import Ticket model
+        from models.ticket import Ticket
+
         # Delete in correct order to respect foreign key constraints
         db.query(UserAdministrative).delete()
         db.query(CustomerAdministrative).delete()
+        db.query(Ticket).delete()
         db.query(Message).delete()
         db.query(Customer).delete()
         db.query(KnowledgeBase).delete()
@@ -76,3 +80,71 @@ def client(db_session):
     with TestClient(app) as test_client:
         yield test_client
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_headers_factory(db_session):
+    """Factory fixture to create auth headers for admin or EO users."""
+    from models.user import User, UserType
+    from models.administrative import UserAdministrative
+    from utils.auth import create_access_token
+
+    def _create_auth_headers(
+        user_type: str = "eo",
+        email: str = None,
+        administrative_ids: list = None,
+        **user_kwargs,
+    ) -> tuple[dict, User]:
+        """
+        Create authentication headers for testing.
+
+        Args:
+            user_type: 'admin' or 'eo' (extension officer)
+            email: Optional custom email (auto-generated if not provided)
+            administrative_ids: List of administrative IDs to assign to
+            EO users
+            **user_kwargs: Additional user attributes
+                (full_name, phone_number, etc.)
+
+        Returns:
+            tuple: (auth_headers dict, user object)
+        """
+        # Set defaults based on user type
+        if user_type == "admin":
+            email = email or "admin@example.com"
+            phone = user_kwargs.get("phone_number", "+10000000001")
+            full_name = user_kwargs.get("full_name", "Admin User")
+            user_type_enum = UserType.ADMIN
+        else:
+            email = email or "eo@example.com"
+            phone = user_kwargs.get("phone_number", "+10000000002")
+            full_name = user_kwargs.get("full_name", "Extension Officer")
+            user_type_enum = UserType.EXTENSION_OFFICER
+
+        # Create user
+        user = User(
+            email=email,
+            phone_number=phone,
+            full_name=full_name,
+            user_type=user_type_enum,
+            hashed_password="hashed",
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        # Assign administrative areas to EO users
+        if user_type_enum == UserType.EXTENSION_OFFICER and administrative_ids:
+            for admin_id in administrative_ids:
+                user_admin = UserAdministrative(
+                    user_id=user.id, administrative_id=admin_id
+                )
+                db_session.add(user_admin)
+            db_session.commit()
+
+        # Generate JWT token
+        token = create_access_token(data={"sub": user.email})
+        return {"Authorization": f"Bearer {token}"}, user
+
+    return _create_auth_headers

--- a/backend/tests/test_seeder_tickets.py
+++ b/backend/tests/test_seeder_tickets.py
@@ -1,0 +1,112 @@
+import uuid
+from passlib.context import CryptContext
+from models.user import User, UserType
+from models.administrative import Administrative
+from models.customer import Customer
+from models.message import Message
+from models.ticket import Ticket
+from seeder.administrative import seed_administrative_data
+from seeder.ticket import (
+    seed_customers,
+    seed_messages,
+    seed_tickets,
+)
+from models.administrative import UserAdministrative
+
+
+class TestSeederTickets:
+    def test_seeder_tickets(self, db_session):
+        # Seed users and administrative areas first
+        # Seed an administrative via commands
+        rows = [
+            {
+                "code": "LOC1",
+                "name": "Location 1",
+                "level": "Country",
+                "parent_code": ""
+            },
+            {
+                "code": "LOC2",
+                "name": "Location 2",
+                "level": "Region",
+                "parent_code": "LOC1"
+            },
+            {
+                "code": "LOC3",
+                "name": "Location 3",
+                "level": "District",
+                "parent_code": "LOC2"
+            },
+        ]
+        seed_administrative_data(db_session, rows)
+        # Seed users and assign to administrative areas
+        # This part is assumed to be implemented in another seeder
+        # For simplicity, we assume users are already seeded and assigned
+        unique_id = str(uuid.uuid4())[:8]
+        pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+        user = User(
+            email=f"eo-{unique_id}@example.com",
+            phone_number=f"+123456789{unique_id[:3]}",
+            hashed_password=pwd_context.hash("testpassword123"),
+            full_name="EO User",
+            user_type=UserType.EXTENSION_OFFICER,
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        # Link the user to one administrative area (LOC3)
+        admin = (
+            db_session.query(Administrative)
+            .filter(Administrative.code == "LOC3")
+            .first()
+        )
+        assert admin is not None
+
+        ua = UserAdministrative(user_id=user.id, administrative_id=admin.id)
+        db_session.add(ua)
+        db_session.commit()
+
+        # Now call the seeder helper functions directly using the test DB
+        customers = seed_customers(db_session, administrative=admin, total=2)
+        assert len(customers) == 2
+
+        # Create messages for the first customer
+        msgs = seed_messages(db_session, customer=customers[0], total=3)
+        assert len(msgs) == 3
+
+        # Create a ticket using the first message
+        ticket = seed_tickets(
+            db_session,
+            administrative=admin,
+            customer=customers[0],
+            initial_message=msgs[0],
+        )
+        assert ticket is not None
+
+        # Assertions on DB counts and relationships
+        cust_count = db_session.query(Customer).count()
+        msg_count = db_session.query(Message).count()
+        ticket_count = db_session.query(Ticket).count()
+
+        assert cust_count >= 2
+        assert msg_count >= 3
+        assert ticket_count >= 1
+
+        # Verify links
+        db_session.refresh(ticket)
+        assert ticket.customer_id == customers[0].id
+        assert ticket.administrative_id == admin.id
+        assert ticket.message_id == msgs[0].id
+
+        # Verify that the administrative area has a UserAdministrative linking
+        ua_check = (
+            db_session.query(UserAdministrative)
+            .filter(
+                UserAdministrative.user_id == user.id,
+                UserAdministrative.administrative_id == admin.id,
+            )
+            .first()
+        )
+        assert ua_check is not None

--- a/backend/tests/test_tickets.py
+++ b/backend/tests/test_tickets.py
@@ -1,0 +1,1172 @@
+"""Test cases for the Ticket API endpoints.
+
+This file contains integration-style tests that seed minimal DB state using
+the `db_session` fixture and exercise the tickets endpoints via the test
+client. Each test follows the numbered notes in the original template and
+verifies the shape and minimal content of responses.
+
+Endpoints covered:
+- GET /api/tickets
+- GET /api/tickets/{ticket_id}
+- GET /api/tickets/{ticket_id}/messages
+- POST /api/tickets
+- PATCH /api/tickets/{ticket_id}
+"""
+
+from datetime import datetime
+import pytest
+
+from models.customer import Customer
+from models.message import Message, MessageFrom
+from models.ticket import Ticket
+from models.administrative import Administrative
+from seeder.administrative import seed_administrative_data
+
+
+@pytest.fixture
+def administrative_data(db_session):
+    """Seed administrative data for tests with multiple wards."""
+    rows = [
+        {
+            "code": "TZ",
+            "name": "Tanzania",
+            "level": "Country",
+            "parent_code": "",
+        },
+        {
+            "code": "MWZ",
+            "name": "Mwanza",
+            "level": "Region",
+            "parent_code": "TZ",
+        },
+        {
+            "code": "MWZ-KWM",
+            "name": "Kwimba",
+            "level": "District",
+            "parent_code": "MWZ",
+        },
+        {
+            "code": "MWZ-KWM-NGU",
+            "name": "Ngudu",
+            "level": "Ward",
+            "parent_code": "MWZ-KWM",
+        },
+        {
+            "code": "MWZ-KWM-BUK",
+            "name": "Bukandwe",
+            "level": "Ward",
+            "parent_code": "MWZ-KWM",
+        },
+    ]
+    seed_administrative_data(db_session, rows)
+
+    # Return dict with both wards for easy access in tests
+    ward_ngudu = (
+        db_session.query(Administrative).filter_by(code="MWZ-KWM-NGU").first()
+    )
+    ward_bukandwe = (
+        db_session.query(Administrative).filter_by(code="MWZ-KWM-BUK").first()
+    )
+
+    return {
+        "ward_ngudu": ward_ngudu,
+        "ward_bukandwe": ward_bukandwe,
+    }
+
+
+class TestTickets:
+    def test_create_ticket(self, client, db_session, administrative_data):
+        # 1-2. Create a customer and a message
+        customer = Customer(phone_number="+255100000001", full_name="Farmer A")
+        db_session.add(customer)
+        db_session.commit()
+        db_session.refresh(customer)
+
+        message = Message(
+            message_sid="SMTEST1",
+            customer_id=customer.id,
+            body="Help needed",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message)
+        db_session.commit()
+        db_session.refresh(message)
+
+        # 3-4. Create a ticket and verify response
+        payload = {"customer_id": customer.id, "message_id": message.id}
+        response = client.post("/api/tickets", json=payload)
+
+        # Verify status code (4)
+        assert response.status_code == 201, "Expected 201 Created status"
+        data = response.json()
+
+        # Verify response structure (4, 12)
+        assert "ticket" in data, "Response should contain 'ticket' key"
+        ticket_data = data["ticket"]
+
+        # 6. Ensure ticket is linked to correct customer and message
+        assert (
+            ticket_data["customer"]["id"] == customer.id
+        ), "Customer ID mismatch"
+        assert (
+            ticket_data["customer"]["name"] == customer.full_name
+        ), "Customer name mismatch"
+        assert (
+            ticket_data["message"]["id"] == message.id
+        ), "Message ID mismatch"
+        assert (
+            ticket_data["message"]["body"] == message.body
+        ), "Message body mismatch"
+
+        # 7. Verify ticket number format (timestamp-based)
+        assert "ticket_number" in ticket_data, "Ticket number missing"
+        assert (
+            len(ticket_data["ticket_number"]) == 14
+        ), "Ticket number should be 14 digits (YYYYMMDDHHMMSS)"
+        assert ticket_data[
+            "ticket_number"
+        ].isdigit(), "Ticket number should be numeric"
+
+        # 8. Verify administrative_id is set (default to 1)
+        assert "id" in ticket_data, "Ticket ID missing"
+
+        # 11. Check timestamps are set
+        assert (
+            ticket_data["created_at"] is not None
+        ), "created_at should be set"
+        assert (
+            ticket_data["status"] == "open"
+        ), "New ticket should have 'open' status"
+        assert (
+            ticket_data["resolved_at"] is None
+        ), "New ticket should not have resolved_at"
+        assert (
+            ticket_data["resolver"] is None
+        ), "New ticket should not have resolver"
+
+        # Verify ticket persisted in DB (6, 8)
+        created = (
+            db_session.query(Ticket)
+            .filter(
+                Ticket.message_id == message.id,
+                Ticket.customer_id == customer.id,
+            )
+            .first()
+        )
+        assert created is not None, "Ticket should be persisted in database"
+        assert (
+            created.message_id == message.id
+        ), "DB ticket message_id mismatch"
+        assert (
+            created.customer_id == customer.id
+        ), "DB ticket customer_id mismatch"
+        assert (
+            created.administrative_id is not None
+        ), "administrative_id should be set"
+        assert (
+            created.ticket_number == ticket_data["ticket_number"]
+        ), "Ticket number mismatch"
+
+        # 9. Test with invalid customer_id
+        invalid_customer_payload = {
+            "customer_id": 99999,
+            "message_id": message.id,
+        }
+        invalid_customer_response = client.post(
+            "/api/tickets", json=invalid_customer_payload
+        )
+        assert (
+            invalid_customer_response.status_code == 404
+        ), "Should return 404 for invalid customer_id"
+        assert (
+            "Customer not found" in invalid_customer_response.json()["detail"]
+        )
+
+        # 9. Test with invalid message_id
+        invalid_message_payload = {
+            "customer_id": customer.id,
+            "message_id": 99999,
+        }
+        invalid_message_response = client.post(
+            "/api/tickets", json=invalid_message_payload
+        )
+        assert (
+            invalid_message_response.status_code == 404
+        ), "Should return 404 for invalid message_id"
+        assert "Message not found" in invalid_message_response.json()["detail"]
+
+        # 10. Test duplicate ticket creation (message already linked)
+        duplicate_payload = {
+            "customer_id": customer.id,
+            "message_id": message.id,
+        }
+        duplicate_response = client.post(
+            "/api/tickets", json=duplicate_payload
+        )
+        assert (
+            duplicate_response.status_code == 400
+        ), "Should return 400 for duplicate message_id"
+        assert "already linked" in duplicate_response.json()["detail"].lower()
+
+    def test_list_tickets(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        # 1. Test with both admin and EO authentication
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+        admin_headers, admin_user = auth_headers_factory(user_type="admin")
+
+        # Seed customers, messages, and tickets
+        c1 = Customer(phone_number="+255200000001", full_name="Customer One")
+        c2 = Customer(phone_number="+255200000002", full_name="Customer Two")
+        c3 = Customer(phone_number="+255200000003", full_name="Customer Three")
+        db_session.add_all([c1, c2, c3])
+        db_session.commit()
+
+        m1 = Message(
+            message_sid="LT1",
+            customer_id=c1.id,
+            body="Message A",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        m2 = Message(
+            message_sid="LT2",
+            customer_id=c2.id,
+            body="Message B",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        m3 = Message(
+            message_sid="LT3",
+            customer_id=c3.id,
+            body="Message C",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add_all([m1, m2, m3])
+        db_session.commit()
+
+        # Create EO users for different wards
+        eo1_headers, eo1_user = auth_headers_factory(
+            user_type="eo",
+            email="eo1@example.com",
+            phone_number="+10000000003",
+            full_name="EO Ward Ngudu",
+            administrative_ids=[administrative_data["ward_ngudu"].id],
+        )
+
+        eo2_headers, eo2_user = auth_headers_factory(
+            user_type="eo",
+            email="eo2@example.com",
+            phone_number="+10000000004",
+            full_name="EO Ward Bukandwe",
+            administrative_ids=[administrative_data["ward_bukandwe"].id],
+        )
+
+        # Create open tickets in different wards
+        t1 = Ticket(
+            ticket_number="T001",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=c1.id,
+            message_id=m1.id,
+            last_message_at=datetime(2025, 1, 3),
+        )
+        t2 = Ticket(
+            ticket_number="T002",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=c2.id,
+            message_id=m2.id,
+            last_message_at=datetime(2025, 1, 2),
+        )
+        t3 = Ticket(
+            ticket_number="T003",
+            administrative_id=administrative_data["ward_bukandwe"].id,
+            customer_id=c3.id,
+            message_id=m3.id,
+            resolved_at=datetime(2025, 1, 1),
+            resolved_by=admin_user.id,
+            last_message_at=datetime(2025, 1, 1),
+        )
+        db_session.add_all([t1, t2, t3])
+        db_session.commit()
+
+        # 1, 13. Test EO1 can only access tickets in their ward (Ngudu)
+        eo1_response = client.get(
+            "/api/tickets?status=open&page=1&page_size=10", headers=eo1_headers
+        )
+        assert (
+            eo1_response.status_code == 200
+        ), "EO should be able to access tickets"
+        eo1_data = eo1_response.json()
+        assert (
+            eo1_data["total"] == 2
+        ), "EO1 should see only 2 tickets from Ngudu ward"
+        for ticket in eo1_data["tickets"]:
+            # Verify ticket belongs to Ngudu ward
+            db_ticket = (
+                db_session.query(Ticket)
+                .filter(Ticket.id == ticket["id"])
+                .first()
+            )
+            assert (
+                db_ticket.administrative_id
+                == administrative_data["ward_ngudu"].id
+            ), "EO1 should only see Ngudu ward tickets"
+
+        # 13. Test EO2 can only access tickets in their ward (Bukandwe)
+        eo2_response = client.get(
+            "/api/tickets?status=open&page=1&page_size=10", headers=eo2_headers
+        )
+        assert (
+            eo2_response.status_code == 200
+        ), "EO2 should be able to access tickets"
+        eo2_data = eo2_response.json()
+        assert (
+            eo2_data["total"] == 0
+        ), "EO2 should see 0 open tickets (only resolved ticket in Bukandwe)"
+
+        # Test EO2 can see resolved tickets in their ward
+        eo2_resolved_response = client.get(
+            "/api/tickets?status=resolved&page=1&page_size=10",
+            headers=eo2_headers,
+        )
+        assert eo2_resolved_response.status_code == 200
+        eo2_resolved_data = eo2_resolved_response.json()
+        assert (
+            eo2_resolved_data["total"] == 1
+        ), "EO2 should see 1 resolved ticket in Bukandwe"
+
+        # 1. Test admin can access tickets from all wards
+        response = client.get(
+            "/api/tickets?status=open&page=1&page_size=10",
+            headers=admin_headers,
+        )
+        assert (
+            response.status_code == 200
+        ), "Admin should be able to access tickets"
+
+        # 1. Test admin can access tickets
+        response = client.get(
+            "/api/tickets?status=open&page=1&page_size=10",
+            headers=admin_headers,
+        )
+        assert (
+            response.status_code == 200
+        ), "Admin should be able to access tickets"
+        payload = response.json()
+
+        # 3, 7. Verify response structure
+        assert "tickets" in payload, "Response should contain 'tickets' key"
+        assert "total" in payload, "Response should contain 'total' key"
+        assert "page" in payload, "Response should contain 'page' key"
+        assert "size" in payload, "Response should contain 'size' key"
+
+        # 4, 7. Verify pagination parameters
+        assert isinstance(payload["total"], int), "total should be an integer"
+        assert payload["page"] == 1, "page should be 1"
+        assert payload["size"] == 10, "size should be 10"
+
+        # 2. Test status=open filtering
+        assert payload["total"] == 2, "Should have 2 open tickets"
+        assert len(payload["tickets"]) == 2, "Should return 2 open tickets"
+
+        # 8, 11. Validate each ticket object and sorting
+        tickets = payload["tickets"]
+        for i, ticket in enumerate(tickets):
+            assert "id" in ticket, "Ticket should have 'id'"
+            assert (
+                "ticket_number" in ticket
+            ), "Ticket should have 'ticket_number'"
+            assert "customer" in ticket, "Ticket should have 'customer'"
+            assert "id" in ticket["customer"], "Customer should have 'id'"
+            assert "name" in ticket["customer"], "Customer should have 'name'"
+            assert "message" in ticket, "Ticket should have 'message'"
+            assert "id" in ticket["message"], "Message should have 'id'"
+            assert "body" in ticket["message"], "Message should have 'body'"
+            assert ticket["status"] == "open", "Status should be 'open'"
+            assert "created_at" in ticket, "Ticket should have 'created_at'"
+            assert (
+                ticket["resolved_at"] is None
+            ), "Open ticket should not have resolved_at"
+            assert (
+                ticket["resolver"] is None
+            ), "Open ticket should not have resolver"
+            assert (
+                "last_message_at" in ticket
+            ), "Ticket should have 'last_message_at'"
+
+            # 11. Verify descending order by last_message_at
+            if i > 0:
+                prev_ts = tickets[i - 1]["last_message_at"]
+                curr_ts = ticket["last_message_at"]
+                assert (
+                    prev_ts >= curr_ts
+                ), "Tickets should be sorted by last_message_at descending"
+
+        # 2. Test status=resolved filtering
+        resolved_response = client.get(
+            "/api/tickets?status=resolved&page=1&page_size=10",
+            headers=admin_headers,
+        )
+        assert resolved_response.status_code == 200
+        resolved_payload = resolved_response.json()
+        assert resolved_payload["total"] == 1, "Should have 1 resolved ticket"
+        resolved_ticket = resolved_payload["tickets"][0]
+        assert (
+            resolved_ticket["status"] == "resolved"
+        ), "Status should be 'resolved'"
+        assert (
+            resolved_ticket["resolved_at"] is not None
+        ), "Resolved ticket should have resolved_at"
+        assert (
+            resolved_ticket["resolver"] is not None
+        ), "Resolved ticket should have resolver"
+        assert (
+            resolved_ticket["resolver"]["id"] == admin_user.id
+        ), "Resolver should match admin user"
+
+        # 4, 10. Test different page sizes
+        small_page_response = client.get(
+            "/api/tickets?status=open&page=1&page_size=1",
+            headers=admin_headers,
+        )
+        assert small_page_response.status_code == 200
+        small_page_payload = small_page_response.json()
+        assert small_page_payload["size"] == 1, "Page size should be 1"
+        assert (
+            len(small_page_payload["tickets"]) == 1
+        ), "Should return 1 ticket"
+        assert small_page_payload["total"] == 2, "Total should still be 2"
+
+        # 6. Test page number exceeding total pages
+        beyond_response = client.get(
+            "/api/tickets?status=open&page=999&page_size=10",
+            headers=admin_headers,
+        )
+        assert (
+            beyond_response.status_code == 200
+        ), "Should handle page beyond total"
+        beyond_payload = beyond_response.json()
+        assert (
+            len(beyond_payload["tickets"]) == 0
+        ), "Should return empty list for page beyond total"
+        assert beyond_payload["total"] == 2, "Total should still be correct"
+
+        # 12. Test empty results (no tickets with specific filter)
+        # Clean database and test
+        db_session.query(Ticket).delete()
+        db_session.commit()
+        empty_response = client.get(
+            "/api/tickets?status=open&page=1&page_size=10",
+            headers=admin_headers,
+        )
+        assert (
+            empty_response.status_code == 200
+        ), "Should handle no tickets gracefully"
+        empty_payload = empty_response.json()
+        assert empty_payload["total"] == 0, "Total should be 0"
+        assert (
+            len(empty_payload["tickets"]) == 0
+        ), "Tickets list should be empty"
+
+    def test_get_ticket_header(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        # 1. Create auth headers for both admin and EO
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+        admin_headers, admin_user = auth_headers_factory(user_type="admin")
+
+        # Create a ticket record
+        customer = Customer(phone_number="+255100000002", full_name="Farmer B")
+        db_session.add(customer)
+        db_session.commit()
+
+        message = Message(
+            message_sid="SMTEST2",
+            customer_id=customer.id,
+            body="Issue",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message)
+        db_session.commit()
+
+        # Create EO users for different wards
+        eo1_headers, eo1_user = auth_headers_factory(
+            user_type="eo",
+            email="eo1@example.com",
+            phone_number="+10000000003",
+            full_name="EO Ward Ngudu",
+            administrative_ids=[administrative_data["ward_ngudu"].id],
+        )
+
+        eo2_headers, eo2_user = auth_headers_factory(
+            user_type="eo",
+            email="eo2@example.com",
+            phone_number="+10000000004",
+            full_name="EO Ward Bukandwe",
+            administrative_ids=[administrative_data["ward_bukandwe"].id],
+        )
+
+        # Create tickets in different wards
+        ticket_ngudu = Ticket(
+            ticket_number="20251101000001",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_ngudu)
+        db_session.commit()
+        db_session.refresh(ticket_ngudu)
+
+        message_buk = Message(
+            message_sid="SMTEST2B",
+            customer_id=customer.id,
+            body="Issue in Bukandwe",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_buk)
+        db_session.commit()
+
+        ticket_bukandwe = Ticket(
+            ticket_number="20251101000002",
+            administrative_id=administrative_data["ward_bukandwe"].id,
+            customer_id=customer.id,
+            message_id=message_buk.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_bukandwe)
+        db_session.commit()
+        db_session.refresh(ticket_bukandwe)
+
+        # 1, 8. Test EO1 can access ticket in their ward (Ngudu)
+        eo1_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}", headers=eo1_headers
+        )
+        assert (
+            eo1_response.status_code == 200
+        ), "EO1 should be able to access ticket in their ward"
+
+        # 8. Test EO1 cannot access ticket outside their ward (Bukandwe)
+        eo1_forbidden_response = client.get(
+            f"/api/tickets/{ticket_bukandwe.id}", headers=eo1_headers
+        )
+        assert (
+            eo1_forbidden_response.status_code == 403
+        ), "EO1 should not be able to access ticket outside their ward"
+        assert (
+            "administrative area"
+            in eo1_forbidden_response.json()["detail"].lower()
+        ), "Error should mention administrative area"
+
+        # 1. Test admin can access tickets from both wards
+        response_ngudu = client.get(
+            f"/api/tickets/{ticket_ngudu.id}", headers=admin_headers
+        )
+        assert (
+            response_ngudu.status_code == 200
+        ), "Admin should be able to access Ngudu ticket"
+
+        response_bukandwe = client.get(
+            f"/api/tickets/{ticket_bukandwe.id}", headers=admin_headers
+        )
+        assert (
+            response_bukandwe.status_code == 200
+        ), "Admin should be able to access Bukandwe ticket"
+
+        # Use ticket_ngudu for remaining validation tests
+        response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}", headers=admin_headers
+        )
+        data = response.json()
+
+        # 2, 6. Verify response structure
+        assert "ticket" in data, "Response should contain 'ticket' key"
+        t = data["ticket"]
+
+        # 3, 6. Validate returned header shape and content
+        assert "id" in t, "Ticket should have 'id'"
+        assert t["id"] == ticket_ngudu.id, "Ticket ID should match"
+        assert "ticket_number" in t, "Ticket should have 'ticket_number'"
+        assert (
+            t["ticket_number"] == ticket_ngudu.ticket_number
+        ), "Ticket number should match"
+
+        # 5, 6. Check customer details
+        assert "customer" in t, "Ticket should have 'customer'"
+        assert t["customer"]["id"] == customer.id, "Customer ID should match"
+        assert (
+            t["customer"]["name"] == customer.full_name
+        ), "Customer name should match"
+
+        # 5, 6. Check message details
+        assert "message" in t, "Ticket should have 'message'"
+        assert t["message"]["id"] == message.id, "Message ID should match"
+        assert (
+            t["message"]["body"] == message.body
+        ), "Message body should match"
+
+        # 6, 7. Check status and timestamps for open ticket
+        assert "status" in t, "Ticket should have 'status'"
+        assert (
+            t["status"] == "open"
+        ), "Status should be 'open' (no resolved_at)"
+        assert "created_at" in t, "Ticket should have 'created_at'"
+        assert t["created_at"] is not None, "created_at should be set"
+        assert (
+            t["resolved_at"] is None
+        ), "Open ticket should not have resolved_at"
+        assert t["resolver"] is None, "Open ticket should not have resolver"
+        assert "last_message_at" in t, "Ticket should have 'last_message_at'"
+
+        # Test with resolved ticket (7)
+        message_resolved = Message(
+            message_sid="SMTEST2C",
+            customer_id=customer.id,
+            body="Resolved issue",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_resolved)
+        db_session.commit()
+
+        resolved_ticket = Ticket(
+            ticket_number="20251101000003",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message_resolved.id,
+            resolved_at=datetime.utcnow(),
+            resolved_by=admin_user.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(resolved_ticket)
+        db_session.commit()
+        db_session.refresh(resolved_ticket)
+
+        resolved_response = client.get(
+            f"/api/tickets/{resolved_ticket.id}", headers=admin_headers
+        )
+        assert resolved_response.status_code == 200
+        resolved_data = resolved_response.json()["ticket"]
+        assert (
+            resolved_data["status"] == "resolved"
+        ), "Status should be 'resolved' when resolved_at is set"
+        assert (
+            resolved_data["resolved_at"] is not None
+        ), "Resolved ticket should have resolved_at"
+        assert (
+            resolved_data["resolver"] is not None
+        ), "Resolved ticket should have resolver"
+        assert (
+            resolved_data["resolver"]["id"] == admin_user.id
+        ), "Resolver ID should match"
+        assert (
+            resolved_data["resolver"]["name"] == admin_user.full_name
+        ), "Resolver name should match"
+
+        # 4, 10. Invalid ticket id returns 404
+        not_found = client.get("/api/tickets/999999", headers=admin_headers)
+        assert (
+            not_found.status_code == 404
+        ), "Should return 404 for invalid ticket ID"
+        assert (
+            "not found" in not_found.json()["detail"].lower()
+        ), "Error message should indicate ticket not found"
+
+        # 9. Test unauthorized access (no auth header)
+        unauth_response = client.get(f"/api/tickets/{ticket_ngudu.id}")
+        assert (
+            unauth_response.status_code == 403
+        ), "Should return 403 for unauthorized access"
+
+    def test_get_ticket_conversation(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        # 1. Create auth headers for both admin and EO
+        admin_headers, admin_user = auth_headers_factory(user_type="admin")
+
+        # Seed a ticket and messages
+        customer = Customer(phone_number="+255100000003", full_name="Farmer C")
+        db_session.add(customer)
+        db_session.commit()
+
+        # Create EO users for different wards
+        eo1_headers, eo1_user = auth_headers_factory(
+            user_type="eo",
+            email="eo1@example.com",
+            phone_number="+10000000005",
+            full_name="EO Ward Ngudu Conv",
+            administrative_ids=[administrative_data["ward_ngudu"].id],
+        )
+
+        eo2_headers, eo2_user = auth_headers_factory(
+            user_type="eo",
+            email="eo2@example.com",
+            phone_number="+10000000006",
+            full_name="EO Ward Bukandwe Conv",
+            administrative_ids=[administrative_data["ward_bukandwe"].id],
+        )
+
+        # Create messages with different timestamps for testing ordering
+        msg_base = Message(
+            message_sid="SMTEST3",
+            customer_id=customer.id,
+            body="Question",
+            from_source=MessageFrom.CUSTOMER,
+            created_at=datetime(2025, 1, 1, 10, 0, 0),
+        )
+        db_session.add(msg_base)
+        db_session.commit()
+
+        # Create ticket in Ngudu ward
+        ticket_ngudu = Ticket(
+            ticket_number="20251101000002",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=msg_base.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_ngudu)
+        db_session.commit()
+        db_session.refresh(ticket_ngudu)
+
+        # Create additional messages for conversation
+        msg1 = Message(
+            message_sid="C1",
+            customer_id=customer.id,
+            body="First message",
+            from_source=MessageFrom.CUSTOMER,
+            created_at=datetime(2025, 1, 1, 11, 0, 0),
+        )
+        msg2 = Message(
+            message_sid="C2",
+            customer_id=customer.id,
+            body="Second message",
+            from_source=MessageFrom.USER,
+            created_at=datetime(2025, 1, 1, 12, 0, 0),
+        )
+        msg3 = Message(
+            message_sid="C3",
+            customer_id=customer.id,
+            body="Third message",
+            from_source=MessageFrom.CUSTOMER,
+            created_at=datetime(2025, 1, 1, 13, 0, 0),
+        )
+        db_session.add_all([msg1, msg2, msg3])
+        db_session.commit()
+
+        # Create ticket in Bukandwe ward for testing EO restrictions
+        msg_buk = Message(
+            message_sid="SMTEST3B",
+            customer_id=customer.id,
+            body="Question in Bukandwe",
+            from_source=MessageFrom.CUSTOMER,
+            created_at=datetime(2025, 1, 1, 10, 0, 0),
+        )
+        db_session.add(msg_buk)
+        db_session.commit()
+
+        ticket_bukandwe = Ticket(
+            ticket_number="20251101000003",
+            administrative_id=administrative_data["ward_bukandwe"].id,
+            customer_id=customer.id,
+            message_id=msg_buk.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_bukandwe)
+        db_session.commit()
+        db_session.refresh(ticket_bukandwe)
+
+        # 12. Test EO1 can access conversation in their ward (Ngudu)
+        eo1_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?limit=10",
+            headers=eo1_headers,
+        )
+        assert (
+            eo1_response.status_code == 200
+        ), "EO1 should be able to access conversation in their ward"
+
+        # 12. Test EO1 cannot access conversation outside their ward
+        eo1_forbidden_response = client.get(
+            f"/api/tickets/{ticket_bukandwe.id}/messages?limit=10",
+            headers=eo1_headers,
+        )
+        assert (
+            eo1_forbidden_response.status_code == 403
+        ), "EO1 should not access conversation outside their ward"
+        assert (
+            "administrative area"
+            in eo1_forbidden_response.json()["detail"].lower()
+        ), "Error should mention administrative area"
+
+        # 1. Test admin can access conversation
+        response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?before_ts=&limit=10",
+            headers=admin_headers,
+        )
+        assert (
+            response.status_code == 200
+        ), "Admin should be able to access ticket conversation"
+        payload = response.json()
+
+        # 2, 6. Verify response structure
+        assert "messages" in payload, "Response should contain 'messages' key"
+        assert "total" in payload, "Response should contain 'total'"
+        assert "before_ts" in payload, "Response should contain 'before_ts'"
+        assert "limit" in payload, "Response should contain 'limit'"
+        assert payload["limit"] == 10, "Limit should match requested value"
+
+        # 9. Validate each message object
+        messages = payload["messages"]
+        # Note: API returns ALL messages for the customer,
+        # not just for this ticket
+        # So we expect: msg_base + msg1 + msg2 + msg3 + msg_buk = 5 messages
+        assert (
+            len(messages) >= 4
+        ), "Should return at least 4 messages for this customer"
+
+        for i, m in enumerate(messages):
+            assert "id" in m, "Message should have 'id'"
+            assert "message_sid" in m, "Message should have 'message_sid'"
+            assert "body" in m, "Message should have 'body'"
+            assert "from_source" in m, "Message should have 'from_source'"
+            assert "message_type" in m, "Message should have 'message_type'"
+            assert "created_at" in m, "Message should have 'created_at'"
+
+            # 7. Verify descending order by created_at
+            if i > 0:
+                prev_ts = messages[i - 1]["created_at"]
+                curr_ts = m["created_at"]
+                assert (
+                    prev_ts >= curr_ts
+                ), "Messages should be sorted by created_at descending"
+
+        # 5, 10. Test with different limit values
+        limited_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?limit=2",
+            headers=admin_headers,
+        )
+        assert limited_response.status_code == 200
+        limited_payload = limited_response.json()
+        assert (
+            len(limited_payload["messages"]) == 2
+        ), "Should return only 2 messages with limit=2"
+        assert limited_payload["limit"] == 2, "Limit should be 2"
+
+        # 5, 8. Test with before_ts parameter
+        middle_ts = datetime(2025, 1, 1, 12, 30, 0).isoformat()
+        before_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?"
+            f"before_ts={middle_ts}&limit=10",
+            headers=admin_headers,
+        )
+        assert before_response.status_code == 200
+        before_payload = before_response.json()
+        # Should return messages before 12:30
+        # (msg2 at 12:00, msg1 at 11:00, msg_base + msg_buk at 10:00)
+        assert (
+            len(before_payload["messages"]) >= 3
+        ), "Should return at least 3 messages before specified timestamp"
+        for msg in before_payload["messages"]:
+            assert (
+                msg["created_at"] < middle_ts
+            ), "All messages should be before specified timestamp"
+
+        # 8. Test with before_ts earlier than all messages
+        early_ts = datetime(2025, 1, 1, 9, 0, 0).isoformat()
+        early_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?"
+            f"before_ts={early_ts}&limit=10",
+            headers=admin_headers,
+        )
+        assert early_response.status_code == 200
+        early_payload = early_response.json()
+        assert (
+            len(early_payload["messages"]) == 0
+        ), "Should return no messages when before_ts is earlier than all"
+
+        # 4, 11. Invalid ticket ID returns 404
+        not_found = client.get(
+            "/api/tickets/99999/messages?limit=10", headers=admin_headers
+        )
+        assert (
+            not_found.status_code == 404
+        ), "Should return 404 for invalid ticket ID"
+        assert (
+            "not found" in not_found.json()["detail"].lower()
+        ), "Error message should indicate ticket not found"
+
+        # 13. Test unauthorized access (no auth header)
+        unauth_response = client.get(
+            f"/api/tickets/{ticket_ngudu.id}/messages?limit=10"
+        )
+        assert (
+            unauth_response.status_code == 403
+        ), "Should return 403 for unauthorized access"
+
+    def test_mark_ticket_resolved(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        # 1. Create auth headers for both admin and EO
+        admin_headers, admin_user = auth_headers_factory(user_type="admin")
+
+        # Seed tickets for testing
+        customer = Customer(phone_number="+255100000004", full_name="Farmer D")
+        db_session.add(customer)
+        db_session.commit()
+
+        # Create EO users for different wards
+        eo1_headers, eo1_user = auth_headers_factory(
+            user_type="eo",
+            email="eo1@example.com",
+            phone_number="+10000000007",
+            full_name="EO Ward Ngudu Resolve",
+            administrative_ids=[administrative_data["ward_ngudu"].id],
+        )
+
+        eo2_headers, eo2_user = auth_headers_factory(
+            user_type="eo",
+            email="eo2@example.com",
+            phone_number="+10000000008",
+            full_name="EO Ward Bukandwe Resolve",
+            administrative_ids=[administrative_data["ward_bukandwe"].id],
+        )
+
+        message = Message(
+            message_sid="SMTEST4",
+            customer_id=customer.id,
+            body="Resolve me",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message)
+        db_session.commit()
+
+        # Create ticket in Ngudu ward
+        ticket_ngudu = Ticket(
+            ticket_number="20251101000003",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_ngudu)
+        db_session.commit()
+        db_session.refresh(ticket_ngudu)
+
+        # Create ticket in Bukandwe ward for testing EO restrictions
+        message_buk = Message(
+            message_sid="SMTEST4B",
+            customer_id=customer.id,
+            body="Resolve me Bukandwe",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_buk)
+        db_session.commit()
+
+        ticket_bukandwe = Ticket(
+            ticket_number="20251101000004",
+            administrative_id=administrative_data["ward_bukandwe"].id,
+            customer_id=customer.id,
+            message_id=message_buk.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_bukandwe)
+        db_session.commit()
+        db_session.refresh(ticket_bukandwe)
+
+        # 10. Prepare payload with valid resolved_at timestamp
+        resolved_timestamp = datetime.utcnow()
+        payload = {"resolved_at": resolved_timestamp.isoformat()}
+
+        # 12. Test EO1 can resolve ticket in their ward (Ngudu)
+        eo1_response = client.patch(
+            f"/api/tickets/{ticket_ngudu.id}",
+            json=payload,
+            headers=eo1_headers,
+        )
+        assert (
+            eo1_response.status_code == 200
+        ), "EO1 should be able to resolve ticket in their ward"
+
+        # 12. Test EO1 cannot resolve ticket outside their ward
+        eo1_forbidden_response = client.patch(
+            f"/api/tickets/{ticket_bukandwe.id}",
+            json=payload,
+            headers=eo1_headers,
+        )
+        assert (
+            eo1_forbidden_response.status_code == 403
+        ), "EO1 should not resolve ticket outside their ward"
+        assert (
+            "administrative area"
+            in eo1_forbidden_response.json()["detail"].lower()
+        ), "Error should mention administrative area"
+
+        # Create new ticket for admin tests
+        message_admin = Message(
+            message_sid="SMTEST4C",
+            customer_id=customer.id,
+            body="Admin test",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_admin)
+        db_session.commit()
+
+        ticket_admin = Ticket(
+            ticket_number="20251101000005",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message_admin.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_admin)
+        db_session.commit()
+        db_session.refresh(ticket_admin)
+
+        # 13. Unauthorized attempt should be rejected (no auth header)
+        unauth = client.patch(f"/api/tickets/{ticket_admin.id}", json=payload)
+        assert (
+            unauth.status_code == 403
+        ), "Should return 403 for unauthorized access"
+
+        # 14. Record before_update timestamp
+        before_update = ticket_admin.updated_at
+
+        # 1, 2, 5, 6. Successful resolution with admin user
+        response = client.patch(
+            f"/api/tickets/{ticket_admin.id}",
+            json=payload,
+            headers=admin_headers,
+        )
+        assert (
+            response.status_code == 200
+        ), "Should successfully resolve ticket"
+        data = response.json()
+
+        # 6. Validate response structure
+        assert "ticket" in data, "Response should contain 'ticket' key"
+        resolved_ticket = data["ticket"]
+
+        # 2, 5. Verify ticket is marked as resolved
+        assert (
+            resolved_ticket["resolved_at"] is not None
+        ), "resolved_at should be set"
+        assert resolved_ticket["resolved_at"].startswith(
+            payload["resolved_at"][:19]
+        ), "resolved_at should match payload (timestamp)"
+        assert (
+            resolved_ticket["status"] == "resolved"
+        ), "Status should be 'resolved'"
+
+        # 9. Verify resolver information
+        assert (
+            resolved_ticket["resolver"] is not None
+        ), "Resolver should be set"
+        assert (
+            resolved_ticket["resolver"]["id"] == admin_user.id
+        ), "Resolver ID should match admin user"
+        assert (
+            resolved_ticket["resolver"]["name"] == admin_user.full_name
+        ), "Resolver name should match"
+
+        # 5, 9, 14. Verify DB was updated
+        db_session.refresh(ticket_admin)
+        assert (
+            ticket_admin.resolved_at is not None
+        ), "resolved_at should be set in DB"
+        assert (
+            ticket_admin.resolved_by == admin_user.id
+        ), "resolved_by should be set to admin user ID"
+        assert ticket_admin.updated_at is not None, "updated_at should be set"
+        if before_update is not None:
+            assert (
+                ticket_admin.updated_at >= before_update
+            ), "updated_at should be updated"
+
+        # 7, 8. Trying to resolve already resolved ticket should fail
+        second = client.patch(
+            f"/api/tickets/{ticket_admin.id}",
+            json=payload,
+            headers=admin_headers,
+        )
+        assert second.status_code in (
+            400,
+            409,
+        ), "Should return 400 or 409 for already resolved ticket"
+        assert (
+            "already resolved" in second.json()["detail"].lower()
+        ), "Error should indicate ticket is already resolved"
+
+        # 11. Invalid timestamp format should return 400
+        # (create new ticket for this test)
+        message_invalid = Message(
+            message_sid="SMTEST4D",
+            customer_id=customer.id,
+            body="Test invalid timestamp",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_invalid)
+        db_session.commit()
+
+        ticket_invalid = Ticket(
+            ticket_number="20251101000010",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message_invalid.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_invalid)
+        db_session.commit()
+        db_session.refresh(ticket_invalid)
+
+        bad_payload = {"resolved_at": "not-a-valid-timestamp"}
+        bad = client.patch(
+            f"/api/tickets/{ticket_invalid.id}",
+            json=bad_payload,
+            headers=admin_headers,
+        )
+        assert (
+            bad.status_code == 400
+        ), "Should return 400 for invalid timestamp format"
+        assert (
+            "invalid" in bad.json()["detail"].lower()
+        ), "Error should indicate invalid format"
+
+        # 4. Invalid ticket id returns 404
+        nf = client.patch(
+            "/api/tickets/999999", json=payload, headers=admin_headers
+        )
+        assert nf.status_code == 404, "Should return 404 for invalid ticket ID"
+        assert (
+            "not found" in nf.json()["detail"].lower()
+        ), "Error should indicate ticket not found"
+
+        # Test missing resolved_at in payload (create new unresolved ticket)
+        message_empty = Message(
+            message_sid="SMTEST6",
+            customer_id=customer.id,
+            body="Test empty payload",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add(message_empty)
+        db_session.commit()
+
+        ticket_empty = Ticket(
+            ticket_number="20251101000011",
+            administrative_id=administrative_data["ward_ngudu"].id,
+            customer_id=customer.id,
+            message_id=message_empty.id,
+            last_message_at=datetime.utcnow(),
+        )
+        db_session.add(ticket_empty)
+        db_session.commit()
+        db_session.refresh(ticket_empty)
+
+        empty_payload = {}
+        empty_response = client.patch(
+            f"/api/tickets/{ticket_empty.id}",
+            json=empty_payload,
+            headers=admin_headers,
+        )
+        assert (
+            empty_response.status_code == 400
+        ), "Should return 400 when resolved_at is missing"
+        assert (
+            "required" in empty_response.json()["detail"].lower()
+        ), "Error should indicate resolved_at is required"


### PR DESCRIPTION
## TODO/DONE

### Mobile app

- [x] Inbox shows only escalated tickets.
- [x] Tabs:
- [x] Pending → open tickets (unresolved).
- [x] Responded → resolved tickets.
- [x] Each row shows: customer name, ticket number, last message snippet + time, unread count, and “Responded by …” when applicable.
- [x] I only see tickets for the ward(s) I am assigned to; no manual ward filter needed.
- [x] Sync between local and online ticket list
- [x] Opening a ticket shows the conversation starting from the escalated message onward.
- [x] Handle unread count

### Backend/APIs

- [x] GET /api/tickets?status=open|resolved&page&page_size → list tickets (filtered by EO’s ward(s) via token).
- [x] GET /api/tickets/{ticket_id} → ticket header.
- [x] GET /api/tickets/{ticket_id}/messages?before_ts&limit → ticket conversation (from escalated message onward).
- [x] POST /api/tickets { customer_id, message_id } → create ticket.
- [x] PATCH /api/tickets/{ticket_id} { resolved_at } → mark ticket resolved.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211449362064804