### PR TITLE
[#100][#105] feat(weather): Add weather intent service and re-subscri…

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -257,6 +257,10 @@ class Settings(BaseSettings):
     # Weather broadcast feature flag
     weather_broadcast_enabled: bool = _config.get("weather", {}).get(
         "broadcast_enabled", False
+    )
+    # Keywords for detecting weather-related messages
+    weather_intent_keywords: List[str] = _config.get("weather", {}).get(
+        "intent_keywords", ["weather", "forecast", "hali ya hewa"]
     )
 
     @property

--- a/backend/config.template.json
+++ b/backend/config.template.json
@@ -79,6 +79,13 @@
 		"phone_number": "+1234567891"
 	},
 	"weather": {
-		"broadcast_enabled": true
+		"broadcast_enabled": true,
+		"intent_keywords": [
+			"weather",
+			"forecast",
+			"weather updates",
+			"hali ya hewa",
+			"hali ya anga"
+		]
 	}
 }

--- a/backend/seeder/reset_onboarding.py
+++ b/backend/seeder/reset_onboarding.py
@@ -9,6 +9,8 @@ import argparse
 from database import SessionLocal
 from models.customer import Customer, OnboardingStatus
 from models.administrative import CustomerAdministrative
+from models.message import Message
+from models.weather_broadcast import WeatherBroadcastRecipient
 
 
 def main():
@@ -46,11 +48,20 @@ def main():
         db.query(CustomerAdministrative).filter(
             CustomerAdministrative.customer_id == customer.id
         ).delete()
+        # Delete weather broadcast recipients first (foreign key to messages)
+        db.query(WeatherBroadcastRecipient).filter(
+            WeatherBroadcastRecipient.customer_id == customer.id
+        ).delete()
+        # Delete all messages for this customer (makes them "new" again)
+        message_count = db.query(Message).filter(
+            Message.customer_id == customer.id
+        ).delete()
         db.commit()
         print(
             f"Reset onboarding status for customer "
             f"{phone_number} to 'not_started'."
         )
+        print(f"Deleted {message_count} messages.")
         return
     # If no phone number is provided, print message and exit
     print(

--- a/backend/services/weather_intent_service.py
+++ b/backend/services/weather_intent_service.py
@@ -1,0 +1,244 @@
+"""
+Weather Intent Service for AgriConnect.
+
+Handles detection and response to weather-related messages from farmers.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from config import settings
+from models.administrative import Administrative, AdministrativeLevel
+from models.customer import Customer
+from services.weather_broadcast_service import get_weather_broadcast_service
+from services.weather_subscription_service import (
+    get_weather_subscription_service,
+)
+from services.whatsapp_service import WhatsAppService
+from utils.i18n import t
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WeatherIntentResult:
+    """Result of handling a weather intent."""
+
+    handled: bool
+    message: str
+    weather_message: Optional[str] = None
+
+
+class WeatherIntentService:
+    """
+    Service for handling weather-related message intents.
+
+    Detects weather keywords and responds with weather forecasts,
+    optionally offering subscription to non-subscribed farmers.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.whatsapp_service = WhatsAppService()
+        self.weather_broadcast_service = get_weather_broadcast_service()
+        self.weather_subscription_service = get_weather_subscription_service(
+            db
+        )
+
+    def has_weather_intent(self, message: str) -> bool:
+        """
+        Check if message contains weather-related keywords.
+
+        Args:
+            message: The message text to check
+
+        Returns:
+            bool: True if weather intent detected
+        """
+        message_lower = message.lower()
+        keywords = settings.weather_intent_keywords
+
+        return any(keyword in message_lower for keyword in keywords)
+
+    def can_handle(
+        self, customer: Customer, has_existing_ticket: bool
+    ) -> bool:
+        """
+        Check if weather intent can be handled for this customer.
+
+        Conditions:
+        - Customer has completed onboarding
+        - Customer has an administrative area assigned
+        - No existing escalated ticket
+
+        Args:
+            customer: The customer object
+            has_existing_ticket: Whether customer has an unresolved ticket
+
+        Returns:
+            bool: True if weather intent can be handled
+        """
+        from models.customer import OnboardingStatus
+
+        return (
+            customer.onboarding_status == OnboardingStatus.COMPLETED
+            and customer.customer_administrative
+            and len(customer.customer_administrative) > 0
+            and not has_existing_ticket
+        )
+
+    def _build_location_path(self, admin_area: Administrative) -> str:
+        """
+        Build full location path from administrative hierarchy.
+
+        Format: "Region, District, Ward" (comma-separated, top-down)
+        Excludes country level (causes wrong API results).
+
+        Args:
+            admin_area: The administrative area object
+
+        Returns:
+            str: Full location path for weather API
+        """
+        path_parts = []
+        current = admin_area
+
+        while current:
+            # Skip country level - causes wrong weather API results
+            level = self.db.query(AdministrativeLevel).filter(
+                AdministrativeLevel.id == current.level_id
+            ).first()
+            if level and level.name != 'country':
+                path_parts.append(current.name)
+            if not current.parent_id:
+                break
+            current = self.db.query(Administrative).filter(
+                Administrative.id == current.parent_id
+            ).first()
+
+        # Reverse to get top-down order (Region, District, Ward)
+        path_parts.reverse()
+        return ", ".join(path_parts)
+
+    async def handle_weather_intent(
+        self,
+        customer: Customer,
+        phone_number: str,
+    ) -> WeatherIntentResult:
+        """
+        Handle a weather intent by generating and sending weather message.
+
+        Args:
+            customer: The customer requesting weather info
+            phone_number: Customer's phone number
+
+        Returns:
+            WeatherIntentResult with status and any generated message
+        """
+        # Check if weather service is configured
+        if not self.weather_broadcast_service.is_configured():
+            logger.warning(
+                "Weather broadcast service not configured, "
+                "cannot handle weather intent"
+            )
+            return WeatherIntentResult(
+                handled=False,
+                message="Weather service not configured",
+            )
+
+        # Get customer's administrative area for location
+        admin_area = customer.customer_administrative[0].administrative
+        location = self._build_location_path(admin_area)
+
+        # Get customer's language
+        lang = customer.language.value if customer.language else "en"
+
+        # Generate weather message
+        weather_svc = self.weather_broadcast_service
+        weather_message = await weather_svc.generate_message(
+            location=location,
+            language=lang,
+        )
+
+        if not weather_message:
+            logger.warning(
+                f"Failed to generate weather message for {location}"
+            )
+            return WeatherIntentResult(
+                handled=False,
+                message="Failed to generate weather message",
+            )
+
+        # Send weather message
+        self.whatsapp_service.send_message(phone_number, weather_message)
+        logger.info(
+            f"Weather message sent to {phone_number} for {location}"
+        )
+
+        # Show subscription buttons if NOT already subscribed
+        if customer.weather_subscribed is not True:
+            self._send_subscription_buttons(
+                customer, phone_number, admin_area.name, lang
+            )
+
+        return WeatherIntentResult(
+            handled=True,
+            message="Weather intent handled",
+            weather_message=weather_message,
+        )
+
+    def _send_subscription_buttons(
+        self,
+        customer: Customer,
+        phone_number: str,
+        area_name: str,
+        lang: str,
+    ) -> None:
+        """
+        Send weather subscription buttons to customer.
+
+        Args:
+            customer: The customer object
+            phone_number: Customer's phone number
+            area_name: Name of the administrative area
+            lang: Language code ("en" or "sw")
+        """
+        self.whatsapp_service.send_interactive_buttons(
+            to_number=phone_number,
+            body_text=t(
+                "weather_subscription.question", lang
+            ).replace("{area_name}", area_name),
+            buttons=[
+                {
+                    "id": settings.weather_yes_payload,
+                    "title": t("weather_subscription.button_yes", lang),
+                },
+                {
+                    "id": settings.weather_no_payload,
+                    "title": t("weather_subscription.button_no", lang),
+                },
+            ],
+        )
+
+        # Mark as asked so button responses work
+        if not customer.weather_subscription_asked:
+            self.weather_subscription_service.mark_as_asked(customer)
+
+        logger.info(f"Weather subscription buttons sent to {phone_number}")
+
+
+def get_weather_intent_service(db: Session) -> WeatherIntentService:
+    """
+    Factory function to create WeatherIntentService instance.
+
+    Args:
+        db: Database session
+
+    Returns:
+        WeatherIntentService instance
+    """
+    return WeatherIntentService(db)

--- a/backend/tests/test_weather_intent.py
+++ b/backend/tests/test_weather_intent.py
@@ -1,0 +1,525 @@
+"""
+Tests for Weather Intent Handling (FLOW 2E)
+
+Tests the feature where farmers can message about weather and receive
+weather forecasts directly, with subscription options for non-subscribers.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from models.customer import Customer, CustomerLanguage, OnboardingStatus
+from models.administrative import Administrative, CustomerAdministrative
+from seeder.administrative import seed_administrative_data
+
+
+class TestWeatherIntentHandling:
+    """Tests for FLOW 2E: Weather intent detection and handling"""
+
+    def _create_completed_customer(
+        self, db_session: Session, phone_number: str = "+255123456789"
+    ) -> tuple[Customer, Administrative]:
+        """Helper to create customer with completed onboarding and admin"""
+        # Create administrative area
+        rows = [
+            {
+                "code": "NAIROBI",
+                "name": "Nairobi",
+                "level": "Ward",
+                "parent_code": "",
+            }
+        ]
+        seed_administrative_data(db_session, rows)
+
+        admin = (
+            db_session.query(Administrative)
+            .filter(Administrative.code == "NAIROBI")
+            .first()
+        )
+
+        # Create customer
+        customer = Customer(
+            phone_number=phone_number,
+            language=CustomerLanguage.EN,
+            onboarding_status=OnboardingStatus.COMPLETED,
+        )
+        db_session.add(customer)
+        db_session.commit()
+        db_session.refresh(customer)
+
+        # Link customer to admin area
+        customer_admin = CustomerAdministrative(
+            customer_id=customer.id,
+            administrative_id=admin.id,
+        )
+        db_session.add(customer_admin)
+        db_session.commit()
+
+        return customer, admin
+
+    @pytest.mark.asyncio
+    async def test_weather_intent_declined_user_gets_message_and_buttons(
+        self, client: TestClient, db_session: Session
+    ):
+        """
+        Farmer who declined weather subscription sends message with
+        weather keywords → gets weather message + subscription buttons
+        """
+        customer, admin = self._create_completed_customer(db_session)
+
+        # Mark customer as declined weather subscription
+        customer.weather_subscription_asked = True
+        customer.weather_subscribed = False
+        db_session.commit()
+
+        with (
+            patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+            patch("routers.whatsapp.get_onboarding_service") as mock_onb_svc,
+            patch(
+                "services.weather_intent_service.get_weather_broadcast_service"
+            ) as mock_weather_svc,
+            patch(
+                "services.weather_intent_service.WhatsAppService"
+            ) as mock_wa_intent,
+        ):
+            # Setup mocks
+            mock_wa_instance = Mock()
+            mock_wa_class.return_value = mock_wa_instance
+            mock_wa_intent.return_value = mock_wa_instance
+
+            mock_onb_instance = Mock()
+            mock_onb_instance.needs_onboarding.return_value = False
+            mock_onb_svc.return_value = mock_onb_instance
+
+            # Mock weather broadcast service
+            mock_weather_instance = Mock()
+            mock_weather_instance.is_configured.return_value = True
+            mock_weather_instance.generate_message = AsyncMock(
+                return_value="Today's weather for Nairobi: Sunny, 25°C"
+            )
+            mock_weather_svc.return_value = mock_weather_instance
+
+            response = client.post(
+                "/api/whatsapp/webhook",
+                data={
+                    "From": f"whatsapp:{customer.phone_number}",
+                    "Body": "What is the weather forecast?",
+                    "MessageSid": "SM_WEATHER_TEST_1",
+                },
+            )
+
+            assert response.status_code == 200
+            assert response.json()["message"] == "Weather intent handled"
+
+            # Verify weather message was generated
+            mock_weather_instance.generate_message.assert_called_once()
+
+            # Verify weather message was sent
+            mock_wa_instance.send_message.assert_called_once()
+            call_args = mock_wa_instance.send_message.call_args
+            assert "weather" in call_args[0][1].lower()
+
+            # Verify subscription buttons were sent
+            mock_wa_instance.send_interactive_buttons.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_weather_intent_subscribed_user_gets_message_only(
+        self, client: TestClient, db_session: Session
+    ):
+        """
+        Farmer who is already subscribed sends message with weather keywords
+        → gets weather message only (no subscription buttons)
+        """
+        customer, admin = self._create_completed_customer(
+            db_session, "+255987654321"
+        )
+
+        # Mark customer as subscribed
+        customer.weather_subscription_asked = True
+        customer.weather_subscribed = True
+        db_session.commit()
+
+        with (
+            patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+            patch("routers.whatsapp.get_onboarding_service") as mock_onb_svc,
+            patch(
+                "services.weather_intent_service.get_weather_broadcast_service"
+            ) as mock_weather_svc,
+            patch(
+                "services.weather_intent_service.WhatsAppService"
+            ) as mock_wa_intent,
+        ):
+            mock_wa_instance = Mock()
+            mock_wa_class.return_value = mock_wa_instance
+            mock_wa_intent.return_value = mock_wa_instance
+
+            mock_onb_instance = Mock()
+            mock_onb_instance.needs_onboarding.return_value = False
+            mock_onb_svc.return_value = mock_onb_instance
+
+            mock_weather_instance = Mock()
+            mock_weather_instance.is_configured.return_value = True
+            mock_weather_instance.generate_message = AsyncMock(
+                return_value="Today's weather for Nairobi: Sunny, 25°C"
+            )
+            mock_weather_svc.return_value = mock_weather_instance
+
+            response = client.post(
+                "/api/whatsapp/webhook",
+                data={
+                    "From": f"whatsapp:{customer.phone_number}",
+                    "Body": "Tell me about the weather today",
+                    "MessageSid": "SM_WEATHER_TEST_2",
+                },
+            )
+
+            assert response.status_code == 200
+            assert response.json()["message"] == "Weather intent handled"
+
+            # Verify weather message was sent
+            mock_wa_instance.send_message.assert_called_once()
+
+            # Verify NO subscription buttons were sent
+            mock_wa_instance.send_interactive_buttons.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_weather_intent_never_asked_user_gets_buttons(
+        self, client: TestClient, db_session: Session
+    ):
+        """
+        Farmer who has never been asked about subscription sends weather
+        message → gets weather message + subscription buttons
+        """
+        customer, admin = self._create_completed_customer(
+            db_session, "+255111222333"
+        )
+
+        # Customer never asked about weather (defaults)
+        assert customer.weather_subscription_asked is False
+        assert customer.weather_subscribed is None
+
+        with (
+            patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+            patch("routers.whatsapp.get_onboarding_service") as mock_onb_svc,
+            patch(
+                "services.weather_intent_service.get_weather_broadcast_service"
+            ) as mock_weather_svc,
+            patch(
+                "services.weather_intent_service.WhatsAppService"
+            ) as mock_wa_intent,
+            patch(
+                "services.weather_intent_service"
+                ".get_weather_subscription_service"
+            ) as mock_sub_svc,
+        ):
+            mock_wa_instance = Mock()
+            mock_wa_class.return_value = mock_wa_instance
+            mock_wa_intent.return_value = mock_wa_instance
+
+            mock_onb_instance = Mock()
+            mock_onb_instance.needs_onboarding.return_value = False
+            mock_onb_svc.return_value = mock_onb_instance
+
+            mock_weather_instance = Mock()
+            mock_weather_instance.is_configured.return_value = True
+            mock_weather_instance.generate_message = AsyncMock(
+                return_value="Today's weather for Nairobi: Sunny, 25°C"
+            )
+            mock_weather_svc.return_value = mock_weather_instance
+
+            mock_sub_instance = Mock()
+            mock_sub_svc.return_value = mock_sub_instance
+
+            response = client.post(
+                "/api/whatsapp/webhook",
+                data={
+                    "From": f"whatsapp:{customer.phone_number}",
+                    "Body": "hali ya hewa",  # Swahili for "weather"
+                    "MessageSid": "SM_WEATHER_TEST_3",
+                },
+            )
+
+            assert response.status_code == 200
+            assert response.json()["message"] == "Weather intent handled"
+
+            # Verify subscription buttons were sent
+            mock_wa_instance.send_interactive_buttons.assert_called_once()
+
+            # Verify mark_as_asked was called
+            mock_sub_instance.mark_as_asked.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_weather_keywords_swahili(
+        self, client: TestClient, db_session: Session
+    ):
+        """Test that Swahili weather keywords are detected"""
+        customer, admin = self._create_completed_customer(
+            db_session, "+255444555666"
+        )
+        customer.weather_subscribed = False
+        customer.weather_subscription_asked = True
+        db_session.commit()
+
+        swahili_keywords = ["hali ya hewa", "hali ya anga"]
+
+        for keyword in swahili_keywords:
+            with (
+                patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+                patch(
+                    "routers.whatsapp.get_onboarding_service"
+                ) as mock_onb_svc,
+                patch(
+                    "services.weather_intent_service"
+                    ".get_weather_broadcast_service"
+                ) as mock_weather_svc,
+                patch(
+                    "services.weather_intent_service.WhatsAppService"
+                ) as mock_wa_intent,
+            ):
+                mock_wa_instance = Mock()
+                mock_wa_class.return_value = mock_wa_instance
+                mock_wa_intent.return_value = mock_wa_instance
+
+                mock_onb_instance = Mock()
+                mock_onb_instance.needs_onboarding.return_value = False
+                mock_onb_svc.return_value = mock_onb_instance
+
+                mock_weather_instance = Mock()
+                mock_weather_instance.is_configured.return_value = True
+                mock_weather_instance.generate_message = AsyncMock(
+                    return_value="Weather info"
+                )
+                mock_weather_svc.return_value = mock_weather_instance
+
+                response = client.post(
+                    "/api/whatsapp/webhook",
+                    data={
+                        "From": f"whatsapp:{customer.phone_number}",
+                        "Body": f"Niambie kuhusu {keyword}",
+                        "MessageSid": f"SM_SW_{keyword.replace(' ', '_')}",
+                    },
+                )
+
+                assert response.status_code == 200
+                msg = response.json()["message"]
+                assert msg == "Weather intent handled", (
+                    f"Failed for keyword: {keyword}"
+                )
+
+
+class TestWeatherResubscription:
+    """Tests for re-subscription after decline"""
+
+    def _create_declined_customer(
+        self, db_session: Session, phone_number: str
+    ) -> Customer:
+        """Create customer who declined weather subscription"""
+        rows = [
+            {
+                "code": "MOMBASA",
+                "name": "Mombasa",
+                "level": "Ward",
+                "parent_code": "",
+            }
+        ]
+        seed_administrative_data(db_session, rows)
+
+        admin = (
+            db_session.query(Administrative)
+            .filter(Administrative.code == "MOMBASA")
+            .first()
+        )
+
+        customer = Customer(
+            phone_number=phone_number,
+            language=CustomerLanguage.EN,
+            onboarding_status=OnboardingStatus.COMPLETED,
+            weather_subscription_asked=True,
+            weather_subscribed=False,
+        )
+        db_session.add(customer)
+        db_session.commit()
+        db_session.refresh(customer)
+
+        customer_admin = CustomerAdministrative(
+            customer_id=customer.id,
+            administrative_id=admin.id,
+        )
+        db_session.add(customer_admin)
+        db_session.commit()
+
+        return customer
+
+    def test_resubscribe_via_button_after_decline(
+        self, client: TestClient, db_session: Session
+    ):
+        """
+        Farmer who previously declined can re-subscribe via button click
+        """
+        customer = self._create_declined_customer(
+            db_session, "+255777888999"
+        )
+
+        assert customer.weather_subscribed is False
+
+        with (
+            patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+            patch("routers.whatsapp.get_onboarding_service") as mock_onb_svc,
+        ):
+            mock_wa_instance = Mock()
+            mock_wa_class.return_value = mock_wa_instance
+
+            mock_onb_instance = Mock()
+            mock_onb_instance.needs_onboarding.return_value = False
+            mock_onb_svc.return_value = mock_onb_instance
+
+            # Simulate clicking "Yes" button for weather subscription
+            response = client.post(
+                "/api/whatsapp/webhook",
+                data={
+                    "From": f"whatsapp:{customer.phone_number}",
+                    "Body": "",
+                    "ButtonPayload": "weather_yes",
+                    "MessageSid": "SM_RESUB_YES",
+                },
+            )
+
+            assert response.status_code == 200
+            msg = response.json()["message"]
+            assert msg == "Weather subscription processed"
+
+            # Verify customer is now subscribed
+            db_session.refresh(customer)
+            assert customer.weather_subscribed is True
+
+    def test_decline_again_via_button(
+        self, client: TestClient, db_session: Session
+    ):
+        """
+        Farmer can decline again after being shown subscription buttons
+        """
+        customer = self._create_declined_customer(
+            db_session, "+255666777888"
+        )
+
+        with (
+            patch("routers.whatsapp.WhatsAppService") as mock_wa_class,
+            patch("routers.whatsapp.get_onboarding_service") as mock_onb_svc,
+        ):
+            mock_wa_instance = Mock()
+            mock_wa_class.return_value = mock_wa_instance
+
+            mock_onb_instance = Mock()
+            mock_onb_instance.needs_onboarding.return_value = False
+            mock_onb_svc.return_value = mock_onb_instance
+
+            # Simulate clicking "No" button
+            response = client.post(
+                "/api/whatsapp/webhook",
+                data={
+                    "From": f"whatsapp:{customer.phone_number}",
+                    "Body": "",
+                    "ButtonPayload": "weather_no",
+                    "MessageSid": "SM_RESUB_NO",
+                },
+            )
+
+            assert response.status_code == 200
+            msg = response.json()["message"]
+            assert msg == "Weather subscription processed"
+
+            # Verify customer remains unsubscribed
+            db_session.refresh(customer)
+            assert customer.weather_subscribed is False
+
+
+class TestWeatherIntentService:
+    """Unit tests for WeatherIntentService"""
+
+    def test_has_weather_intent_english(self):
+        """Test English weather keyword detection"""
+        from services.weather_intent_service import WeatherIntentService
+
+        service = WeatherIntentService(db=Mock())
+
+        assert service.has_weather_intent("What is the weather?")
+        assert service.has_weather_intent("Give me the forecast")
+        assert service.has_weather_intent("weather updates please")
+        assert not service.has_weather_intent("How to plant maize?")
+        assert not service.has_weather_intent("Will it rain today?")
+
+    def test_has_weather_intent_swahili(self):
+        """Test Swahili weather keyword detection"""
+        from services.weather_intent_service import WeatherIntentService
+
+        service = WeatherIntentService(db=Mock())
+
+        assert service.has_weather_intent("hali ya hewa leo")
+        assert service.has_weather_intent("hali ya anga kesho")
+        assert not service.has_weather_intent("je kuna mvua?")
+        assert not service.has_weather_intent("jinsi ya kupanda mahindi")
+
+    def test_can_handle_completed_customer(self, db_session: Session):
+        """Test can_handle for completed customer with admin area"""
+        from services.weather_intent_service import WeatherIntentService
+
+        # Create customer with admin area
+        rows = [
+            {
+                "code": "TEST_AREA",
+                "name": "Test Area",
+                "level": "Ward",
+                "parent_code": "",
+            }
+        ]
+        seed_administrative_data(db_session, rows)
+
+        admin = (
+            db_session.query(Administrative)
+            .filter(Administrative.code == "TEST_AREA")
+            .first()
+        )
+
+        customer = Customer(
+            phone_number="+255999888777",
+            language=CustomerLanguage.EN,
+            onboarding_status=OnboardingStatus.COMPLETED,
+        )
+        db_session.add(customer)
+        db_session.commit()
+
+        customer_admin = CustomerAdministrative(
+            customer_id=customer.id,
+            administrative_id=admin.id,
+        )
+        db_session.add(customer_admin)
+        db_session.commit()
+        db_session.refresh(customer)
+
+        service = WeatherIntentService(db=db_session)
+
+        # Should handle: completed, has admin, no ticket
+        assert service.can_handle(customer, has_existing_ticket=False)
+
+        # Should not handle: has existing ticket
+        assert not service.can_handle(customer, has_existing_ticket=True)
+
+    def test_can_handle_incomplete_customer(self, db_session: Session):
+        """Test can_handle for customer still in onboarding"""
+        from services.weather_intent_service import WeatherIntentService
+
+        customer = Customer(
+            phone_number="+255888777666",
+            language=CustomerLanguage.EN,
+            onboarding_status=OnboardingStatus.IN_PROGRESS,
+        )
+        db_session.add(customer)
+        db_session.commit()
+
+        service = WeatherIntentService(db=db_session)
+
+        # Should not handle: onboarding not complete
+        assert not service.can_handle(customer, has_existing_ticket=False)


### PR DESCRIPTION
…ption flow

- Add WeatherIntentService to handle weather keyword detection
- Move weather intent keywords to config.json for easy customization
- Allow farmers to re-subscribe after declining weather updates
- Send welcome message after weather question for new customers
- Update reset_onboarding to delete messages and weather recipients
- Add comprehensive tests for weather intent handling