### PR TITLE
[#110] feat(onboarding): Add data sharing consent step after language…

### DIFF
--- a/backend/models/customer.py
+++ b/backend/models/customer.py
@@ -144,6 +144,25 @@ class Customer(Base):
     def weather_subscribed(self, value: bool | None):
         self.set_profile_field("weather_subscribed", value)
 
+    # Data consent properties
+    @property
+    def data_consent_asked(self) -> bool:
+        """Check if data consent question was asked."""
+        return self.get_profile_field("data_consent_asked", False)
+
+    @data_consent_asked.setter
+    def data_consent_asked(self, value: bool):
+        self.set_profile_field("data_consent_asked", value)
+
+    @property
+    def data_consent_given(self) -> bool | None:
+        """Data consent status: True=consented, None=not asked."""
+        return self.get_profile_field("data_consent_given", None)
+
+    @data_consent_given.setter
+    def data_consent_given(self, value: bool | None):
+        self.set_profile_field("data_consent_given", value)
+
     def needs_reconnection_template(self, threshold_hours: int = 24) -> bool:
         """
         Check if customer needs reconnection template.

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -420,6 +420,40 @@ trans: Dict[str, Any] = {
             ),
         },
     },
+    "consent": {
+        "data_sharing": {
+            "question": {
+                "en": (
+                    "Your data will be shared with Murang'a County and GODAN "
+                    "for compliance with the ASTGS DTTI storage and program "
+                    "monitoring.\n\n"
+                    "Reply 'Yes' to accept and continue."
+                ),
+                "sw": (
+                    "Data yako itashirikiwa na Kaunti ya Murang'a na GODAN "
+                    "kwa kufuata sheria za ASTGS DTTI na ufuatiliaji wa "
+                    "programu.\n\n"
+                    "Jibu 'Ndiyo' kukubali na kuendelea."
+                ),
+            },
+            "accepted": {
+                "en": "Thank you for your consent!",
+                "sw": "Asante kwa idhini yako!",
+            },
+            "declined": {
+                "en": (
+                    "We understand. Unfortunately, we cannot proceed without "
+                    "your consent to data sharing. If you change your mind, "
+                    "please message us again."
+                ),
+                "sw": (
+                    "Tunaelewa. Kwa bahati mbaya, hatuwezi kuendelea bila "
+                    "idhini yako ya kushiriki data. Ukibadili mawazo, "
+                    "tafadhali tutumie ujumbe tena."
+                ),
+            },
+        },
+    },
 }
 
 


### PR DESCRIPTION
… selection

Add consent statement before continuing onboarding:
- Ask consent in user's selected language after language preference
- Accept affirmative responses (yes, ok, ndiyo, sawa, etc.)
- Delete customer row if consent declined (fresh start on retry)
- Existing users with completed onboarding skip consent

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212761361950686