### PR TITLE
[#134] Add user statistics to mobile app home screen

### DIFF
--- a/app/app/(tabs)/stats.tsx
+++ b/app/app/(tabs)/stats.tsx
@@ -1,25 +1,192 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
+import {
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  TouchableOpacity,
+  RefreshControl,
+} from "react-native";
 import Feathericons from "@expo/vector-icons/Feather";
 import themeColors from "@/styles/colors";
 import typography from "@/styles/typography";
+import { useDatabase } from "@/database";
+import { DAOManager, UserStats } from "@/database/dao";
+import { useNetwork } from "@/contexts/NetworkContext";
+import { api } from "@/services/api";
+
+type TimePeriod = "week" | "month" | "all";
 
 const Stats: React.FC = () => {
+  const db = useDatabase();
+  const dao = useMemo(() => new DAOManager(db), [db]);
+  const { isOnline } = useNetwork();
+
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>("all");
+
+  const fetchStats = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      if (isOnline) {
+        const apiStats = await api.getUserStats();
+        dao.userStats.saveFromApi(db, apiStats);
+        const cachedStats = dao.userStats.get(db);
+        setStats(cachedStats);
+      } else {
+        const cachedStats = dao.userStats.get(db);
+        setStats(cachedStats);
+      }
+    } catch (error) {
+      console.error("Error fetching user stats:", error);
+      const cachedStats = dao.userStats.get(db);
+      setStats(cachedStats);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isOnline, dao, db]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  const getStatValue = (
+    stat: "farmersReached" | "conversationsResolved" | "messagesSent",
+    period: TimePeriod,
+  ): number => {
+    if (!stats) {
+      return 0;
+    }
+    const periodMap = {
+      week: "Week",
+      month: "Month",
+      all: "All",
+    };
+    const key = `${stat}${periodMap[period]}` as keyof UserStats;
+    return (stats[key] as number) ?? 0;
+  };
+
+  const periodLabels: Record<TimePeriod, string> = {
+    week: "This Week",
+    month: "This Month",
+    all: "All Time",
+  };
+
+  const statCards = [
+    {
+      key: "farmersReached" as const,
+      label: "Farmers Reached",
+      icon: "user-plus" as const,
+      description: "Unique customers you have messaged",
+    },
+    {
+      key: "conversationsResolved" as const,
+      label: "Conversations Resolved",
+      icon: "check-circle" as const,
+      description: "Tickets you have resolved",
+    },
+    {
+      key: "messagesSent" as const,
+      label: "Messages Sent",
+      icon: "message-circle" as const,
+      description: "Total messages you have sent",
+    },
+  ];
+
   return (
-    <View style={styles.container}>
-      <View style={styles.content}>
-        <Feathericons
-          name="bar-chart-2"
-          size={64}
-          color={themeColors["green-300"]}
-          style={styles.icon}
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      refreshControl={
+        <RefreshControl
+          refreshing={isLoading}
+          onRefresh={fetchStats}
+          colors={[themeColors["green-500"]]}
+          tintColor={themeColors["green-500"]}
         />
-        <Text style={styles.title}>Coming Soon</Text>
-        <Text style={styles.subtitle}>
-          Statistics and analytics will be available here
+      }
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Your Statistics</Text>
+        <Text style={styles.headerSubtitle}>
+          Track your performance and impact
         </Text>
       </View>
-    </View>
+
+      {/* Period Selector */}
+      <View style={styles.periodSelector}>
+        {(["week", "month", "all"] as TimePeriod[]).map((period) => (
+          <TouchableOpacity
+            key={period}
+            style={[
+              styles.periodButton,
+              selectedPeriod === period && styles.periodButtonActive,
+            ]}
+            onPress={() => setSelectedPeriod(period)}
+          >
+            <Text
+              style={[
+                styles.periodButtonText,
+                selectedPeriod === period && styles.periodButtonTextActive,
+              ]}
+            >
+              {periodLabels[period]}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Stats Cards */}
+      <View style={styles.statsContainer}>
+        {statCards.map((stat) => (
+          <View key={stat.key} style={styles.statCard}>
+            <View style={styles.statHeader}>
+              <View style={styles.statIconContainer}>
+                <Feathericons
+                  name={stat.icon}
+                  size={24}
+                  color={themeColors["green-500"]}
+                />
+              </View>
+              <Text style={styles.statValue}>
+                {getStatValue(stat.key, selectedPeriod)}
+              </Text>
+            </View>
+            <Text style={styles.statLabel}>{stat.label}</Text>
+            <Text style={styles.statDescription}>{stat.description}</Text>
+          </View>
+        ))}
+
+        {/* Average Response Time Card (placeholder) */}
+        <View style={[styles.statCard, styles.statCardDisabled]}>
+          <View style={styles.statHeader}>
+            <View
+              style={[styles.statIconContainer, styles.statIconContainerMuted]}
+            >
+              <Feathericons
+                name="clock"
+                size={24}
+                color={themeColors.textSecondary}
+              />
+            </View>
+            <Text style={[styles.statValue, styles.statValueMuted]}>--</Text>
+          </View>
+          <Text style={[styles.statLabel, styles.statLabelMuted]}>
+            Average Response Time
+          </Text>
+          <Text style={styles.statDescription}>Coming soon</Text>
+        </View>
+      </View>
+
+      {/* Last updated */}
+      {stats?.updatedAt && (
+        <Text style={styles.lastUpdated}>
+          Last updated: {new Date(stats.updatedAt).toLocaleString()}
+        </Text>
+      )}
+    </ScrollView>
   );
 };
 
@@ -28,25 +195,107 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: themeColors.background,
   },
-  content: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 32,
+  contentContainer: {
+    padding: 16,
+    paddingBottom: 32,
   },
-  icon: {
-    marginBottom: 16,
+  header: {
+    marginBottom: 24,
+    paddingTop: 48,
   },
-  title: {
+  headerTitle: {
     ...typography.heading4,
     fontWeight: "bold",
     color: themeColors.textPrimary,
-    marginBottom: 8,
+    marginBottom: 4,
   },
-  subtitle: {
+  headerSubtitle: {
     ...typography.body2,
     color: themeColors.textSecondary,
+  },
+  periodSelector: {
+    flexDirection: "row",
+    backgroundColor: themeColors.white,
+    borderRadius: 12,
+    padding: 4,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: themeColors.mutedBorder,
+  },
+  periodButton: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  periodButtonActive: {
+    backgroundColor: themeColors["green-500"],
+  },
+  periodButtonText: {
+    ...typography.label2,
+    fontWeight: "600",
+    color: themeColors.textSecondary,
+  },
+  periodButtonTextActive: {
+    color: themeColors.white,
+  },
+  statsContainer: {
+    gap: 16,
+  },
+  statCard: {
+    backgroundColor: themeColors.white,
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: themeColors.cardBorder,
+  },
+  statCardDisabled: {
+    opacity: 0.6,
+  },
+  statHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  statIconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    backgroundColor: themeColors["green-50"],
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  statIconContainerMuted: {
+    backgroundColor: themeColors.mutedBorder,
+  },
+  statValue: {
+    ...typography.heading3,
+    fontWeight: "bold",
+    color: themeColors["green-500"],
+  },
+  statValueMuted: {
+    color: themeColors.textSecondary,
+  },
+  statLabel: {
+    ...typography.label1,
+    fontWeight: "bold",
+    color: themeColors.textPrimary,
+    marginBottom: 4,
+  },
+  statLabelMuted: {
+    color: themeColors.textSecondary,
+  },
+  statDescription: {
+    ...typography.body3,
+    color: themeColors.textSecondary,
+  },
+  lastUpdated: {
+    ...typography.caption1,
+    color: themeColors.textSecondary,
     textAlign: "center",
+    marginTop: 24,
   },
 });
 

--- a/app/database/config.ts
+++ b/app/database/config.ts
@@ -1,2 +1,2 @@
-export const DATABASE_VERSION: number = 9;
+export const DATABASE_VERSION: number = 10;
 export const DATABASE_NAME: string = "agriconnect.db";

--- a/app/database/dao/index.ts
+++ b/app/database/dao/index.ts
@@ -4,6 +4,7 @@ import { CustomerUserDAO } from "./customerUserDAO";
 import { MessageDAO } from "./messageDAO";
 import { ProfileDAO } from "./profileDAO";
 import { TicketDAO } from "./ticketDAO";
+import { UserStatsDAO } from "./userStatsDAO";
 
 /**
  * DAO Manager - Central access point for all database operations
@@ -23,6 +24,7 @@ export class DAOManager {
   public readonly message: MessageDAO;
   public readonly profile: ProfileDAO;
   public readonly ticket: TicketDAO;
+  public readonly userStats: UserStatsDAO;
 
   constructor(db: SQLiteDatabase) {
     // Verify database is properly initialized
@@ -38,6 +40,7 @@ export class DAOManager {
     this.message = new MessageDAO(this.db);
     this.profile = new ProfileDAO(this.db);
     this.ticket = new TicketDAO(this.db);
+    this.userStats = new UserStatsDAO();
   }
 
   /**

--- a/app/database/dao/types/index.ts
+++ b/app/database/dao/types/index.ts
@@ -3,3 +3,4 @@ export * from "./user";
 export * from "./customerUser";
 export * from "./message";
 export * from "./profile";
+export * from "./userStats";

--- a/app/database/dao/types/userStats.ts
+++ b/app/database/dao/types/userStats.ts
@@ -1,0 +1,45 @@
+// UserStats types and interfaces
+export interface UserStats {
+  id: number;
+  farmersReachedWeek: number;
+  farmersReachedMonth: number;
+  farmersReachedAll: number;
+  conversationsResolvedWeek: number;
+  conversationsResolvedMonth: number;
+  conversationsResolvedAll: number;
+  messagesSentWeek: number;
+  messagesSentMonth: number;
+  messagesSentAll: number;
+  updatedAt: string;
+}
+
+// API response shape from the backend
+export interface UserStatsApiResponse {
+  farmers_reached: {
+    this_week: number;
+    this_month: number;
+    all_time: number;
+  };
+  conversations_resolved: {
+    this_week: number;
+    this_month: number;
+    all_time: number;
+  };
+  messages_sent: {
+    this_week: number;
+    this_month: number;
+    all_time: number;
+  };
+}
+
+export interface CreateUserStatsData {
+  farmersReachedWeek: number;
+  farmersReachedMonth: number;
+  farmersReachedAll: number;
+  conversationsResolvedWeek: number;
+  conversationsResolvedMonth: number;
+  conversationsResolvedAll: number;
+  messagesSentWeek: number;
+  messagesSentMonth: number;
+  messagesSentAll: number;
+}

--- a/app/database/dao/userStatsDAO.ts
+++ b/app/database/dao/userStatsDAO.ts
@@ -1,0 +1,167 @@
+import { SQLiteDatabase } from "expo-sqlite";
+import { UserStats, CreateUserStatsData, UserStatsApiResponse } from "./types/userStats";
+
+export class UserStatsDAO {
+  private tableName = "user_stats";
+
+  /**
+   * Get the cached user stats (there should only be one row)
+   */
+  get(db: SQLiteDatabase): UserStats | null {
+    const stmt = db.prepareSync(`SELECT * FROM ${this.tableName} LIMIT 1`);
+    try {
+      const result = stmt.executeSync<{
+        id: number;
+        farmers_reached_week: number;
+        farmers_reached_month: number;
+        farmers_reached_all: number;
+        conversations_resolved_week: number;
+        conversations_resolved_month: number;
+        conversations_resolved_all: number;
+        messages_sent_week: number;
+        messages_sent_month: number;
+        messages_sent_all: number;
+        updated_at: string;
+      }>();
+      const row = result.getFirstSync();
+      if (!row) return null;
+
+      return {
+        id: row.id,
+        farmersReachedWeek: row.farmers_reached_week,
+        farmersReachedMonth: row.farmers_reached_month,
+        farmersReachedAll: row.farmers_reached_all,
+        conversationsResolvedWeek: row.conversations_resolved_week,
+        conversationsResolvedMonth: row.conversations_resolved_month,
+        conversationsResolvedAll: row.conversations_resolved_all,
+        messagesSentWeek: row.messages_sent_week,
+        messagesSentMonth: row.messages_sent_month,
+        messagesSentAll: row.messages_sent_all,
+        updatedAt: row.updated_at,
+      };
+    } catch (error) {
+      console.error("Error fetching user stats:", error);
+      return null;
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+
+  /**
+   * Save or update user stats from API response
+   * This method handles the conversion from API format to DB format
+   */
+  saveFromApi(db: SQLiteDatabase, apiResponse: UserStatsApiResponse): boolean {
+    const data: CreateUserStatsData = {
+      farmersReachedWeek: apiResponse.farmers_reached.this_week,
+      farmersReachedMonth: apiResponse.farmers_reached.this_month,
+      farmersReachedAll: apiResponse.farmers_reached.all_time,
+      conversationsResolvedWeek: apiResponse.conversations_resolved.this_week,
+      conversationsResolvedMonth: apiResponse.conversations_resolved.this_month,
+      conversationsResolvedAll: apiResponse.conversations_resolved.all_time,
+      messagesSentWeek: apiResponse.messages_sent.this_week,
+      messagesSentMonth: apiResponse.messages_sent.this_month,
+      messagesSentAll: apiResponse.messages_sent.all_time,
+    };
+
+    return this.upsert(db, data);
+  }
+
+  /**
+   * Insert or update user stats (only one row should exist)
+   */
+  upsert(db: SQLiteDatabase, data: CreateUserStatsData): boolean {
+    const existing = this.get(db);
+    const now = new Date().toISOString();
+
+    try {
+      if (existing) {
+        // Update existing row
+        const stmt = db.prepareSync(`
+          UPDATE ${this.tableName} SET
+            farmers_reached_week = ?,
+            farmers_reached_month = ?,
+            farmers_reached_all = ?,
+            conversations_resolved_week = ?,
+            conversations_resolved_month = ?,
+            conversations_resolved_all = ?,
+            messages_sent_week = ?,
+            messages_sent_month = ?,
+            messages_sent_all = ?,
+            updated_at = ?
+          WHERE id = ?
+        `);
+        try {
+          const result = stmt.executeSync([
+            data.farmersReachedWeek,
+            data.farmersReachedMonth,
+            data.farmersReachedAll,
+            data.conversationsResolvedWeek,
+            data.conversationsResolvedMonth,
+            data.conversationsResolvedAll,
+            data.messagesSentWeek,
+            data.messagesSentMonth,
+            data.messagesSentAll,
+            now,
+            existing.id,
+          ]);
+          return result.changes > 0;
+        } finally {
+          stmt.finalizeSync();
+        }
+      } else {
+        // Insert new row
+        const stmt = db.prepareSync(`
+          INSERT INTO ${this.tableName} (
+            farmers_reached_week,
+            farmers_reached_month,
+            farmers_reached_all,
+            conversations_resolved_week,
+            conversations_resolved_month,
+            conversations_resolved_all,
+            messages_sent_week,
+            messages_sent_month,
+            messages_sent_all,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        try {
+          const result = stmt.executeSync([
+            data.farmersReachedWeek,
+            data.farmersReachedMonth,
+            data.farmersReachedAll,
+            data.conversationsResolvedWeek,
+            data.conversationsResolvedMonth,
+            data.conversationsResolvedAll,
+            data.messagesSentWeek,
+            data.messagesSentMonth,
+            data.messagesSentAll,
+            now,
+          ]);
+          return result.lastInsertRowId > 0;
+        } finally {
+          stmt.finalizeSync();
+        }
+      }
+    } catch (error) {
+      console.error("Error upserting user stats:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Clear all user stats (for logout)
+   */
+  clear(db: SQLiteDatabase): boolean {
+    const stmt = db.prepareSync(`DELETE FROM ${this.tableName}`);
+    try {
+      stmt.executeSync();
+      return true;
+    } catch (error) {
+      console.error("Error clearing user stats:", error);
+      return false;
+    } finally {
+      stmt.finalizeSync();
+    }
+  }
+}

--- a/app/database/migrations/013_create_user_stats.ts
+++ b/app/database/migrations/013_create_user_stats.ts
@@ -1,0 +1,17 @@
+// Create user_stats table for caching user statistics locally
+// This allows offline display of stats fetched from the API
+export const createUserStatsMigration = `
+CREATE TABLE IF NOT EXISTS user_stats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    farmers_reached_week INTEGER NOT NULL DEFAULT 0,
+    farmers_reached_month INTEGER NOT NULL DEFAULT 0,
+    farmers_reached_all INTEGER NOT NULL DEFAULT 0,
+    conversations_resolved_week INTEGER NOT NULL DEFAULT 0,
+    conversations_resolved_month INTEGER NOT NULL DEFAULT 0,
+    conversations_resolved_all INTEGER NOT NULL DEFAULT 0,
+    messages_sent_week INTEGER NOT NULL DEFAULT 0,
+    messages_sent_month INTEGER NOT NULL DEFAULT 0,
+    messages_sent_all INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`;

--- a/app/database/migrations/index.ts
+++ b/app/database/migrations/index.ts
@@ -10,6 +10,7 @@ import { alterProfileAddDeviceRegisterAtMigration } from "./009_alter_profile_ad
 import { alterTicketsAddLastMessageIdMigration } from "./010_alter_tickets_add_lastMessageId";
 import { customerProfileFieldsMigration } from "./011_alter_customer_add_profile";
 import { alterTicketsAddContextMessageIdMigration } from "./012_alter_tickets_add_contextMessageId";
+import { createUserStatsMigration } from "./013_create_user_stats";
 
 // Type definition for migration objects
 export interface Migration {
@@ -60,6 +61,11 @@ export const allMigrations: Migration[] = [
     version: 9,
     name: "alter_tickets_add_contextMessageId",
     migration: alterTicketsAddContextMessageIdMigration,
+  },
+  {
+    version: 10,
+    name: "create_user_stats",
+    migration: createUserStatsMigration,
   },
 ];
 

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -911,6 +911,30 @@ class ApiClient {
 
     return response.json();
   }
+
+  /**
+   * Get user statistics (farmers reached, conversations resolved, messages sent)
+   */
+  async getUserStats(): Promise<{
+    farmers_reached: { this_week: number; this_month: number; all_time: number };
+    conversations_resolved: {
+      this_week: number;
+      this_month: number;
+      all_time: number;
+    };
+    messages_sent: { this_week: number; this_month: number; all_time: number };
+  }> {
+    const response = await this.fetchWithRetry(`${this.baseUrl}/user/stats`);
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ detail: "Failed to fetch user stats" }));
+      throw new Error(error.detail || "Failed to fetch user stats");
+    }
+
+    return response.json();
+  }
 }
 
 export const api = new ApiClient();

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from routers import (
     openai_demo,
     document,
     weather,
+    user_stats,
 )
 from fastapi.staticfiles import StaticFiles
 from services.external_ai_service import ExternalAIService
@@ -113,6 +114,7 @@ app.include_router(storage.router)
 app.include_router(crop_types.router, prefix="/api")
 app.include_router(openai_demo.router)
 app.include_router(weather.router, prefix="/api")
+app.include_router(user_stats.router, prefix="/api")
 
 # Ensure storage directory exists before mounting
 os.makedirs("storage", exist_ok=True)

--- a/backend/routers/user_stats.py
+++ b/backend/routers/user_stats.py
@@ -1,0 +1,130 @@
+import logging
+from datetime import datetime, timezone, timedelta
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func, case, distinct
+
+from database import get_db
+from models.message import Message, MessageFrom
+from models.ticket import Ticket
+from models.user import User
+from utils.auth_dependencies import get_current_user
+
+router = APIRouter(prefix="/user", tags=["user-stats"])
+logger = logging.getLogger(__name__)
+
+
+def _get_week_start() -> datetime:
+    """Get the start of the current week (Monday 00:00:00 UTC)."""
+    now = datetime.now(timezone.utc)
+    days_since_monday = now.weekday()
+    week_start = now - timedelta(days=days_since_monday)
+    return week_start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _get_month_start() -> datetime:
+    """Get the start of the current month (1st day 00:00:00 UTC)."""
+    now = datetime.now(timezone.utc)
+    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+@router.get("/stats")
+async def get_user_stats(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get user statistics for the current user.
+
+    Returns:
+        - farmers_reached: Unique customers the EO has messaged
+        - conversations_resolved: Tickets resolved by the EO
+        - messages_sent: Messages sent by the EO
+
+    Each metric includes this_week, this_month, and all_time counts.
+    """
+    user_id = current_user.id
+    week_start = _get_week_start()
+    month_start = _get_month_start()
+
+    # Farmers Reached - unique customers the EO has messaged
+    farmers_result = db.query(
+        func.count(
+            distinct(
+                case(
+                    (Message.created_at >= week_start, Message.customer_id),
+                    else_=None,
+                )
+            )
+        ).label("this_week"),
+        func.count(
+            distinct(
+                case(
+                    (Message.created_at >= month_start, Message.customer_id),
+                    else_=None,
+                )
+            )
+        ).label("this_month"),
+        func.count(distinct(Message.customer_id)).label("all_time"),
+    ).filter(
+        Message.user_id == user_id,
+        Message.from_source == MessageFrom.USER,
+    ).first()
+
+    # Conversations Resolved
+    resolved_result = db.query(
+        func.count(
+            case(
+                (Ticket.resolved_at >= week_start, 1),
+                else_=None,
+            )
+        ).label("this_week"),
+        func.count(
+            case(
+                (Ticket.resolved_at >= month_start, 1),
+                else_=None,
+            )
+        ).label("this_month"),
+        func.count(Ticket.id).label("all_time"),
+    ).filter(
+        Ticket.resolved_by == user_id,
+        Ticket.resolved_at.isnot(None),
+    ).first()
+
+    # Messages Sent
+    messages_result = db.query(
+        func.count(
+            case(
+                (Message.created_at >= week_start, 1),
+                else_=None,
+            )
+        ).label("this_week"),
+        func.count(
+            case(
+                (Message.created_at >= month_start, 1),
+                else_=None,
+            )
+        ).label("this_month"),
+        func.count(Message.id).label("all_time"),
+    ).filter(
+        Message.user_id == user_id,
+        Message.from_source == MessageFrom.USER,
+    ).first()
+
+    return {
+        "farmers_reached": {
+            "this_week": farmers_result.this_week or 0,
+            "this_month": farmers_result.this_month or 0,
+            "all_time": farmers_result.all_time or 0,
+        },
+        "conversations_resolved": {
+            "this_week": resolved_result.this_week or 0,
+            "this_month": resolved_result.this_month or 0,
+            "all_time": resolved_result.all_time or 0,
+        },
+        "messages_sent": {
+            "this_week": messages_result.this_week or 0,
+            "this_month": messages_result.this_month or 0,
+            "all_time": messages_result.all_time or 0,
+        },
+    }

--- a/backend/tests/test_user_stats.py
+++ b/backend/tests/test_user_stats.py
@@ -1,0 +1,456 @@
+"""Test cases for the User Stats API endpoint.
+
+This file contains tests for the /api/user/stats endpoint that returns
+user statistics: farmers_reached, conversations_resolved, messages_sent.
+"""
+
+from datetime import datetime, timezone, timedelta
+import pytest
+
+from models.customer import Customer
+from models.message import Message, MessageFrom
+from models.ticket import Ticket
+from models.administrative import Administrative
+from seeder.administrative import seed_administrative_data
+
+
+@pytest.fixture
+def administrative_data(db_session):
+    """Seed administrative data for tests."""
+    rows = [
+        {
+            "code": "TZ",
+            "name": "Tanzania",
+            "level": "Country",
+            "parent_code": "",
+        },
+        {
+            "code": "MWZ",
+            "name": "Mwanza",
+            "level": "Region",
+            "parent_code": "TZ",
+        },
+        {
+            "code": "MWZ-KWM",
+            "name": "Kwimba",
+            "level": "District",
+            "parent_code": "MWZ",
+        },
+        {
+            "code": "MWZ-KWM-NGU",
+            "name": "Ngudu",
+            "level": "Ward",
+            "parent_code": "MWZ-KWM",
+        },
+    ]
+    seed_administrative_data(db_session, rows)
+
+    ward = (
+        db_session.query(Administrative).filter_by(code="MWZ-KWM-NGU").first()
+    )
+    return {"ward": ward}
+
+
+class TestUserStats:
+    def test_get_user_stats_requires_auth(self, client):
+        """Test that the endpoint requires authentication."""
+        response = client.get("/api/user/stats")
+        assert response.status_code == 403, (
+            "Should return 403 for unauthenticated requests"
+        )
+
+    def test_get_user_stats_empty(
+        self, client, auth_headers_factory, db_session
+    ):
+        """Test stats endpoint returns zeros when user has no activity."""
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+
+        response = client.get("/api/user/stats", headers=eo_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+
+        # Verify response structure
+        assert "farmers_reached" in data
+        assert "conversations_resolved" in data
+        assert "messages_sent" in data
+
+        # Verify each metric has all time periods
+        for metric in ["farmers_reached", "conversations_resolved",
+                       "messages_sent"]:
+            assert "this_week" in data[metric]
+            assert "this_month" in data[metric]
+            assert "all_time" in data[metric]
+
+        # All values should be 0 for a new user
+        assert data["farmers_reached"]["all_time"] == 0
+        assert data["conversations_resolved"]["all_time"] == 0
+        assert data["messages_sent"]["all_time"] == 0
+
+    def test_get_user_stats_with_data(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        """Test stats endpoint returns correct counts."""
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+
+        # Create customers
+        c1 = Customer(phone_number="+255100000001", full_name="Farmer A")
+        c2 = Customer(phone_number="+255100000002", full_name="Farmer B")
+        c3 = Customer(phone_number="+255100000003", full_name="Farmer C")
+        db_session.add_all([c1, c2, c3])
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+
+        # Create messages sent by the EO to different customers
+        # Messages to c1 (should count as 1 unique farmer)
+        m1 = Message(
+            message_sid="STAT1",
+            customer_id=c1.id,
+            user_id=eo_user.id,
+            body="Hello farmer 1",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        m2 = Message(
+            message_sid="STAT2",
+            customer_id=c1.id,
+            user_id=eo_user.id,
+            body="Another message to farmer 1",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        # Message to c2 (counts as another unique farmer)
+        m3 = Message(
+            message_sid="STAT3",
+            customer_id=c2.id,
+            user_id=eo_user.id,
+            body="Hello farmer 2",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        db_session.add_all([m1, m2, m3])
+        db_session.commit()
+
+        # Create tickets and resolve them
+        # Need customer messages for tickets
+        cm1 = Message(
+            message_sid="CSTAT1",
+            customer_id=c1.id,
+            body="Help needed",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        cm2 = Message(
+            message_sid="CSTAT2",
+            customer_id=c2.id,
+            body="Question",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add_all([cm1, cm2])
+        db_session.commit()
+
+        t1 = Ticket(
+            ticket_number="STAT001",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c1.id,
+            message_id=cm1.id,
+            resolved_at=now,
+            resolved_by=eo_user.id,
+        )
+        t2 = Ticket(
+            ticket_number="STAT002",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c2.id,
+            message_id=cm2.id,
+            resolved_at=now,
+            resolved_by=eo_user.id,
+        )
+        db_session.add_all([t1, t2])
+        db_session.commit()
+
+        # Get stats
+        response = client.get("/api/user/stats", headers=eo_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+
+        # Verify farmers reached (2 unique customers)
+        assert data["farmers_reached"]["all_time"] == 2, (
+            "Should have reached 2 unique farmers"
+        )
+
+        # Verify conversations resolved (2 tickets)
+        assert data["conversations_resolved"]["all_time"] == 2, (
+            "Should have resolved 2 conversations"
+        )
+
+        # Verify messages sent (3 total)
+        assert data["messages_sent"]["all_time"] == 3, (
+            "Should have sent 3 messages"
+        )
+
+    def test_get_user_stats_time_periods(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        """Test stats correctly filter by time periods."""
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+
+        # Create customers
+        c1 = Customer(phone_number="+255200000001", full_name="Time Farmer A")
+        c2 = Customer(phone_number="+255200000002", full_name="Time Farmer B")
+        db_session.add_all([c1, c2])
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+        # Calculate time boundaries
+        week_start = now - timedelta(days=now.weekday())
+        week_start = week_start.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        month_start = now.replace(day=1, hour=0, minute=0, second=0)
+
+        # Message from this week
+        m_week = Message(
+            message_sid="TWEEK1",
+            customer_id=c1.id,
+            user_id=eo_user.id,
+            body="This week message",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        # Message from last month (before this month started)
+        m_old = Message(
+            message_sid="TOLD1",
+            customer_id=c2.id,
+            user_id=eo_user.id,
+            body="Old message",
+            from_source=MessageFrom.USER,
+            created_at=month_start - timedelta(days=35),
+        )
+        db_session.add_all([m_week, m_old])
+        db_session.commit()
+
+        # Create and resolve tickets
+        cm1 = Message(
+            message_sid="TCM1",
+            customer_id=c1.id,
+            body="Help",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        cm2 = Message(
+            message_sid="TCM2",
+            customer_id=c2.id,
+            body="Question",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add_all([cm1, cm2])
+        db_session.commit()
+
+        t_week = Ticket(
+            ticket_number="TWEEK001",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c1.id,
+            message_id=cm1.id,
+            resolved_at=now,
+            resolved_by=eo_user.id,
+        )
+        t_old = Ticket(
+            ticket_number="TOLD001",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c2.id,
+            message_id=cm2.id,
+            resolved_at=month_start - timedelta(days=35),
+            resolved_by=eo_user.id,
+        )
+        db_session.add_all([t_week, t_old])
+        db_session.commit()
+
+        # Get stats
+        response = client.get("/api/user/stats", headers=eo_headers)
+        assert response.status_code == 200
+
+        data = response.json()
+
+        # This week should have 1 farmer, 1 resolved, 1 message
+        assert data["farmers_reached"]["this_week"] == 1
+        assert data["conversations_resolved"]["this_week"] == 1
+        assert data["messages_sent"]["this_week"] == 1
+
+        # This month should have 1 farmer, 1 resolved, 1 message
+        # (old data is from before this month)
+        assert data["farmers_reached"]["this_month"] == 1
+        assert data["conversations_resolved"]["this_month"] == 1
+        assert data["messages_sent"]["this_month"] == 1
+
+        # All time should have 2 farmers, 2 resolved, 2 messages
+        assert data["farmers_reached"]["all_time"] == 2
+        assert data["conversations_resolved"]["all_time"] == 2
+        assert data["messages_sent"]["all_time"] == 2
+
+    def test_get_user_stats_only_counts_own_activity(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        """Test that stats only count the current user's activity."""
+        eo1_headers, eo1_user = auth_headers_factory(
+            user_type="eo",
+            email="eo1@stats.test",
+            phone_number="+10000000010",
+        )
+        eo2_headers, eo2_user = auth_headers_factory(
+            user_type="eo",
+            email="eo2@stats.test",
+            phone_number="+10000000011",
+        )
+
+        # Create customer
+        c1 = Customer(phone_number="+255300000001", full_name="Shared Farmer")
+        db_session.add(c1)
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+
+        # EO1 sends 2 messages
+        m1 = Message(
+            message_sid="EO1M1",
+            customer_id=c1.id,
+            user_id=eo1_user.id,
+            body="EO1 message 1",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        m2 = Message(
+            message_sid="EO1M2",
+            customer_id=c1.id,
+            user_id=eo1_user.id,
+            body="EO1 message 2",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        # EO2 sends 1 message
+        m3 = Message(
+            message_sid="EO2M1",
+            customer_id=c1.id,
+            user_id=eo2_user.id,
+            body="EO2 message 1",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        db_session.add_all([m1, m2, m3])
+        db_session.commit()
+
+        # Create tickets - EO1 resolves 1, EO2 resolves 1
+        cm1 = Message(
+            message_sid="SCM1",
+            customer_id=c1.id,
+            body="Help 1",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        cm2 = Message(
+            message_sid="SCM2",
+            customer_id=c1.id,
+            body="Help 2",
+            from_source=MessageFrom.CUSTOMER,
+        )
+        db_session.add_all([cm1, cm2])
+        db_session.commit()
+
+        t1 = Ticket(
+            ticket_number="SEO1T1",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c1.id,
+            message_id=cm1.id,
+            resolved_at=now,
+            resolved_by=eo1_user.id,
+        )
+        t2 = Ticket(
+            ticket_number="SEO2T1",
+            administrative_id=administrative_data["ward"].id,
+            customer_id=c1.id,
+            message_id=cm2.id,
+            resolved_at=now,
+            resolved_by=eo2_user.id,
+        )
+        db_session.add_all([t1, t2])
+        db_session.commit()
+
+        # EO1 stats
+        eo1_response = client.get("/api/user/stats", headers=eo1_headers)
+        assert eo1_response.status_code == 200
+        eo1_data = eo1_response.json()
+
+        assert eo1_data["farmers_reached"]["all_time"] == 1, (
+            "EO1 should have reached 1 farmer"
+        )
+        assert eo1_data["conversations_resolved"]["all_time"] == 1, (
+            "EO1 should have resolved 1 conversation"
+        )
+        assert eo1_data["messages_sent"]["all_time"] == 2, (
+            "EO1 should have sent 2 messages"
+        )
+
+        # EO2 stats
+        eo2_response = client.get("/api/user/stats", headers=eo2_headers)
+        assert eo2_response.status_code == 200
+        eo2_data = eo2_response.json()
+
+        assert eo2_data["farmers_reached"]["all_time"] == 1, (
+            "EO2 should have reached 1 farmer"
+        )
+        assert eo2_data["conversations_resolved"]["all_time"] == 1, (
+            "EO2 should have resolved 1 conversation"
+        )
+        assert eo2_data["messages_sent"]["all_time"] == 1, (
+            "EO2 should have sent 1 message"
+        )
+
+    def test_get_user_stats_excludes_customer_and_llm_messages(
+        self, client, auth_headers_factory, db_session, administrative_data
+    ):
+        """Test that stats only count USER messages, not CUSTOMER or LLM."""
+        eo_headers, eo_user = auth_headers_factory(user_type="eo")
+
+        c1 = Customer(phone_number="+255400000001", full_name="Message Farmer")
+        db_session.add(c1)
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+
+        # User message (should count)
+        m_user = Message(
+            message_sid="MUSER1",
+            customer_id=c1.id,
+            user_id=eo_user.id,
+            body="EO message",
+            from_source=MessageFrom.USER,
+            created_at=now,
+        )
+        # Customer message (should NOT count)
+        m_customer = Message(
+            message_sid="MCUST1",
+            customer_id=c1.id,
+            body="Customer message",
+            from_source=MessageFrom.CUSTOMER,
+            created_at=now,
+        )
+        # LLM message (should NOT count)
+        m_llm = Message(
+            message_sid="MLLM1",
+            customer_id=c1.id,
+            body="LLM response",
+            from_source=MessageFrom.LLM,
+            created_at=now,
+        )
+        db_session.add_all([m_user, m_customer, m_llm])
+        db_session.commit()
+
+        response = client.get("/api/user/stats", headers=eo_headers)
+        assert response.status_code == 200
+        data = response.json()
+
+        # Only 1 message should be counted (the USER message)
+        assert data["messages_sent"]["all_time"] == 1, (
+            "Should only count USER messages, not CUSTOMER or LLM"
+        )
+        assert data["farmers_reached"]["all_time"] == 1, (
+            "Should count farmer reached via USER message"
+        )


### PR DESCRIPTION
## Summary
- Add `GET /api/user/stats` endpoint to compute live statistics from messages and tickets tables
- Track three metrics: farmers reached, conversations resolved, messages sent
- Support three time periods: this week, this month, all time
- Add SQLite caching for offline support on mobile
- Update Home screen to display real stats with refresh button
- Update Stats page with period selector and detailed breakdown

## Changes
### Backend
- New `/api/user/stats` endpoint with live query computation
- Comprehensive test coverage (6 tests)

### Mobile App
- SQLite migration for `user_stats` cache table
- DAO for managing cached stats
- API service method `getUserStats()`
- Home screen: real stats display + refresh button
- Stats page: period filter (Week/Month/All Time)

## Test plan
- [x] Backend tests pass (`pytest tests/test_user_stats.py`)
- [ ] Verify API returns correct stats with auth header
- [ ] Verify Home screen shows real numbers
- [ ] Verify refresh button fetches new data
- [ ] Verify Stats page period selector works
- [ ] Verify offline mode shows cached data

Closes #134

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211449362064855