### PR TITLE
Add multi-day forecast support to weather API comparison

### DIFF
--- a/scripts/weather_api/comparison/compare_weather_apis.py
+++ b/scripts/weather_api/comparison/compare_weather_apis.py
@@ -3,16 +3,21 @@
 Weather API Comparison Script for Murang'a Districts.
 
 Compares weather data from:
-- OpenWeatherMap (via akvo-weather-info library)
+- OpenWeatherMap API
 - Google Weather API
 
 Usage:
-    python compare_weather_apis.py
+    python compare_weather_apis.py                    # Current conditions, all wards
+    python compare_weather_apis.py --limit=10         # Current conditions, 10 wards
+    python compare_weather_apis.py --days=5           # 5-day forecast, all wards
+    python compare_weather_apis.py --days=3 --limit=5 # 3-day forecast, 5 wards
 
 Output:
-    <datetime>-muranga.csv in the same directory
+    Current:  <datetime>-muranga.csv
+    Forecast: <datetime>-muranga-forecast-<days>d.csv
 """
 
+import argparse
 import csv
 import os
 import requests
@@ -35,8 +40,12 @@ GOOGLE_WEATHER_KEY = os.getenv("GOOGLE_WEATHER_API_KEY")
 ADMIN_CSV = script_dir.parent.parent.parent / "backend" / "source" / "administrative.csv"
 
 
-def load_muranga_wards(limit: int = 10) -> list[dict]:
-    """Load first N wards from Murang'a region with coordinates."""
+def load_muranga_wards(limit: int | None = None) -> list[dict]:
+    """Load wards from Murang'a region with coordinates.
+
+    Args:
+        limit: Maximum number of wards to load. None means all wards.
+    """
     wards = []
     with open(ADMIN_CSV, "r") as f:
         reader = csv.DictReader(f)
@@ -54,7 +63,7 @@ def load_muranga_wards(limit: int = 10) -> list[dict]:
                     "lon": float(row["longitude"]),
                     "lat": float(row["latitude"]),
                 })
-                if len(wards) >= limit:
+                if limit and len(wards) >= limit:
                     break
     return wards
 
@@ -143,23 +152,108 @@ def get_google_weather_data(lat: float, lon: float) -> dict:
         return {"condition": f"Error: {str(e)}", "rain_mm": None}
 
 
-def main():
-    """Main comparison function."""
-    print("=" * 60)
-    print("Weather API Comparison - Murang'a Wards")
-    print("=" * 60)
+def get_openweather_forecast(lat: float, lon: float, days: int) -> list[dict]:
+    """Get multi-day forecast from OpenWeatherMap API."""
+    if not OPENWEATHER_KEY:
+        return [{"date": "N/A", "condition": "API key missing", "rain_mm": None}]
 
-    # Check API keys
-    print("\nAPI Key Status:")
-    print(f"  OpenWeatherMap: {'✓' if OPENWEATHER_KEY else '✗'}")
-    print(f"  Google Weather: {'✓' if GOOGLE_WEATHER_KEY else '✗'}")
-    print()
+    try:
+        url = (
+            f"https://api.openweathermap.org/data/2.5/forecast"
+            f"?lat={lat}&lon={lon}&appid={OPENWEATHER_KEY}&units=metric"
+        )
+        response = requests.get(url, timeout=10)
+        data = response.json()
 
-    # Load wards
-    wards = load_muranga_wards(limit=10)
-    print(f"Loaded {len(wards)} wards from Murang'a\n")
+        if response.status_code != 200:
+            return [{
+                "date": "N/A",
+                "condition": f"Error: {data.get('message', 'Unknown')}",
+                "rain_mm": None
+            }]
 
-    # Collect data
+        # Group by date and get daily summary (noon forecast)
+        daily_forecasts = {}
+        for entry in data.get("list", []):
+            dt = datetime.fromtimestamp(entry["dt"])
+            date_str = dt.strftime("%Y-%m-%d")
+
+            if date_str not in daily_forecasts:
+                # Use first entry of the day as representative
+                condition = entry.get("weather", [{}])[0].get("description", "Unknown")
+                rain_3h = entry.get("rain", {}).get("3h", 0)
+                daily_forecasts[date_str] = {
+                    "date": date_str,
+                    "condition": condition.title(),
+                    "rain_mm": rain_3h,
+                }
+
+            if len(daily_forecasts) >= days:
+                break
+
+        return list(daily_forecasts.values())[:days]
+    except Exception as e:
+        return [{"date": "N/A", "condition": f"Error: {str(e)}", "rain_mm": None}]
+
+
+def get_google_weather_forecast(lat: float, lon: float, days: int) -> list[dict]:
+    """Get multi-day forecast from Google Weather API."""
+    if not GOOGLE_WEATHER_KEY:
+        return [{"date": "N/A", "condition": "API key missing", "rain_mm": None}]
+
+    try:
+        url = (
+            f"https://weather.googleapis.com/v1/forecast/days:lookup"
+            f"?key={GOOGLE_WEATHER_KEY}"
+            f"&location.latitude={lat}&location.longitude={lon}"
+            f"&days={days}"
+        )
+        response = requests.get(url, timeout=10)
+        data = response.json()
+
+        if response.status_code != 200:
+            error_msg = data.get("error", {}).get("message", "Unknown error")
+            return [{
+                "date": "N/A",
+                "condition": f"Error: {error_msg}",
+                "rain_mm": None
+            }]
+
+        forecasts = []
+        for day_forecast in data.get("forecastDays", [])[:days]:
+            # Get date from interval
+            interval = day_forecast.get("interval", {})
+            start_time = interval.get("startTime", "")
+            date_str = start_time[:10] if start_time else "N/A"
+
+            # Get day condition
+            day_part = day_forecast.get("daytimeForecast", {})
+            condition = (
+                day_part.get("weatherCondition", {})
+                .get("description", {})
+                .get("text", "Unknown")
+            )
+
+            # Get precipitation
+            precip = (
+                day_part.get("precipitation", {})
+                .get("qpf", {})
+                .get("quantity", 0)
+            )
+
+            forecasts.append({
+                "date": date_str,
+                "condition": condition,
+                "rain_mm": round(precip, 2) if precip else 0,
+            })
+
+        return forecasts
+    except Exception as e:
+        return [{"date": "N/A", "condition": f"Error: {str(e)}", "rain_mm": None}]
+
+
+def run_current_conditions(wards: list[dict]) -> pd.DataFrame:
+    """Run current conditions comparison."""
     results = []
     for ward in wards:
         print(f"Fetching data for {ward['name']}...")
@@ -175,12 +269,104 @@ def main():
             "Google_Rain_MM": google["rain_mm"],
         })
 
-    # Create DataFrame
+    return pd.DataFrame(results)
+
+
+def format_date_with_day(date_str: str) -> str:
+    """Format date string to include day name (e.g., '2024-03-16 (Saturday)')."""
+    if date_str == "N/A":
+        return date_str
+    try:
+        dt = datetime.strptime(date_str, "%Y-%m-%d")
+        return f"{date_str} ({dt.strftime('%A')})"
+    except ValueError:
+        return date_str
+
+
+def run_forecast(wards: list[dict], days: int) -> pd.DataFrame:
+    """Run multi-day forecast comparison."""
+    results = []
+    for ward in wards:
+        print(f"Fetching {days}-day forecast for {ward['name']}...")
+
+        owm_forecast = get_openweather_forecast(ward["lat"], ward["lon"], days)
+        google_forecast = get_google_weather_forecast(ward["lat"], ward["lon"], days)
+
+        for i in range(days):
+            owm = owm_forecast[i] if i < len(owm_forecast) else {
+                "date": "N/A", "condition": "No data", "rain_mm": None
+            }
+            google = google_forecast[i] if i < len(google_forecast) else {
+                "date": "N/A", "condition": "No data", "rain_mm": None
+            }
+
+            date_str = owm.get("date", google.get("date", "N/A"))
+            results.append({
+                "Location": ward["name"],
+                "Date": format_date_with_day(date_str),
+                "_sort_date": date_str,  # For sorting
+                "OWM_Condition": owm["condition"],
+                "OWM_Rain_MM": owm["rain_mm"],
+                "Google_Condition": google["condition"],
+                "Google_Rain_MM": google["rain_mm"],
+            })
+
+    # Sort by date, then by location
     df = pd.DataFrame(results)
+    df = df.sort_values(["_sort_date", "Location"]).drop(columns=["_sort_date"])
+    return df.reset_index(drop=True)
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare weather APIs for Murang'a wards"
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=0,
+        help="Number of forecast days (0 = current conditions only)"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of wards to process (default: all)"
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Main comparison function."""
+    args = parse_args()
+
+    mode = "Forecast" if args.days > 0 else "Current Conditions"
+    print("=" * 60)
+    print(f"Weather API Comparison - Murang'a Wards ({mode})")
+    print("=" * 60)
+
+    # Check API keys
+    print("\nAPI Key Status:")
+    print(f"  OpenWeatherMap: {'✓' if OPENWEATHER_KEY else '✗'}")
+    print(f"  Google Weather: {'✓' if GOOGLE_WEATHER_KEY else '✗'}")
+    print()
+
+    # Load wards
+    wards = load_muranga_wards(limit=args.limit)
+    print(f"Loaded {len(wards)} wards from Murang'a\n")
+
+    # Run comparison
+    if args.days > 0:
+        df = run_forecast(wards, args.days)
+        suffix = f"-forecast-{args.days}d"
+    else:
+        df = run_current_conditions(wards)
+        suffix = ""
 
     # Generate output filename
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = script_dir / f"{timestamp}-muranga.csv"
+    output_file = script_dir / f"{timestamp}-muranga{suffix}.csv"
 
     # Save to CSV
     df.to_csv(output_file, index=False)


### PR DESCRIPTION
## Summary
- Add `--days` CLI flag to fetch N-day forecasts (default: current conditions only)
- Add `--limit` CLI flag to restrict number of wards processed (default: all 35 wards)
- Include day names in forecast dates (e.g., "2026-03-16 (Monday)")
- Sort forecast results by date first, then by location
- Different output filename for forecasts: `<timestamp>-muranga-forecast-<days>d.csv`

## Usage
```bash
python compare_weather_apis.py                    # Current conditions, all wards
python compare_weather_apis.py --limit=10         # Current conditions, 10 wards
python compare_weather_apis.py --days=5           # 5-day forecast, all wards
python compare_weather_apis.py --days=3 --limit=5 # 3-day forecast, 5 wards
```

## Test plan
- [ ] Run script with no arguments (current conditions, all 35 wards)
- [ ] Run script with `--days=5` for 5-day forecast
- [ ] Run script with `--limit=5` to limit wards
- [ ] Verify output CSV filenames match expected pattern
- [ ] Verify forecast results sorted by date

🤖 Generated with [Claude Code](https://claude.com/claude-code)