### PR TITLE
[#157] Fix onboarding location matching and text refinement

### DIFF
--- a/backend/services/onboarding_service.py
+++ b/backend/services/onboarding_service.py
@@ -69,9 +69,9 @@ class OnboardingService:
         self.supported_crops = settings.crop_types
 
         # Configuration (can be overridden per field)
-        self.match_threshold = 60.0  # Minimum score for consideration
+        self.match_threshold = 30.0  # Minimum score for consideration
         self.ambiguity_threshold = 15.0  # Score difference for ambiguity
-        self.high_confidence_threshold = 90.0  # Auto-select without candidates
+        self.high_confidence_threshold = 90.0  # Auto-select threshold
         self.max_candidates = 5  # Max options to show farmer
 
         # Administrative level hierarchy (in order of selection)
@@ -1202,21 +1202,25 @@ Birth year must be between 1900 and {current_year}."""
         """
         Check if top matches are ambiguous (within threshold).
 
-        Returns True if multiple candidates are within ambiguity_threshold,
-        unless the top match has a high confidence score (e.g., small typo).
+        Returns True if multiple candidates are within ambiguity_threshold.
+        Auto-select only if top score is 90%+ AND significantly higher than
+        second candidate.
         """
         if len(candidates) < 2:
             return False
 
         top_score = candidates[0].score
+        second_score = candidates[1].score
+        score_diff = top_score - second_score
 
-        # High confidence match - auto-select (e.g., "Ithnga" -> "Ithanga")
-        if top_score >= self.high_confidence_threshold:
+        # Only auto-select if high confidence AND significantly better
+        if (
+            top_score >= self.high_confidence_threshold
+            and score_diff > self.ambiguity_threshold
+        ):
             return False
 
-        second_score = candidates[1].score
-
-        return (top_score - second_score) <= self.ambiguity_threshold
+        return score_diff <= self.ambiguity_threshold
 
     # ================================================================
     # MAIN GENERIC ONBOARDING HANDLER
@@ -1634,16 +1638,6 @@ Birth year must be between 1900 and {current_year}."""
         # Get customer language
         lang = customer.language.value if customer.language else "en"
 
-        # Parse selection
-        selection_index = self.parse_selection(message)
-
-        if selection_index is None:
-            return OnboardingResponse(
-                message=t("onboarding.common.invalid_selection", lang),
-                status="awaiting_selection",
-                attempts=self._get_attempts(customer, field_name),
-            )
-
         # Get candidates from JSON
         if not customer.onboarding_candidates or not isinstance(
             customer.onboarding_candidates, dict
@@ -1651,6 +1645,21 @@ Birth year must be between 1900 and {current_year}."""
             candidate_ids = []
         else:
             candidate_ids = customer.onboarding_candidates.get(field_name, [])
+
+        # Parse selection
+        selection_index = self.parse_selection(message)
+
+        if selection_index is None:
+            # User typed text instead of number - do fresh search
+            if field_name == "administration" and candidate_ids:
+                return await self._filter_candidates_by_text(
+                    customer, message, candidate_ids, field_config
+                )
+            return OnboardingResponse(
+                message=t("onboarding.common.invalid_selection", lang),
+                status="awaiting_selection",
+                attempts=self._get_attempts(customer, field_name),
+            )
 
         if selection_index >= len(candidate_ids):
             return OnboardingResponse(
@@ -1685,6 +1694,57 @@ Birth year must be between 1900 and {current_year}."""
 
         # Save the selected value
         return self._save_field_value(customer, selected_obj, field_config)
+
+    async def _filter_candidates_by_text(
+        self,
+        customer: Customer,
+        text: str,
+        candidate_ids: List[int],
+        field_config: OnboardingFieldConfig,
+    ) -> OnboardingResponse:
+        """Re-search locations when user types text instead of number."""
+        field_name = field_config.field_name
+        lang = customer.language.value if customer.language else "en"
+
+        # Extract location from the new text input
+        location = await self.extract_location(text)
+
+        if not location:
+            # Create a simple LocationData with just the text
+            location = LocationData(
+                province=None, district=None, ward=text, full_text=text
+            )
+
+        # Search all wards in database
+        candidates = self.find_lowest_administrative_location(location)
+
+        if not candidates:
+            # No matches - ask user to try again
+            return OnboardingResponse(
+                message=t(
+                    "onboarding.administration.no_match",
+                    lang,
+                    input=text,
+                ),
+                status="awaiting_selection",
+                attempts=self._get_attempts(customer, field_name),
+            )
+
+        # Check for ambiguity
+        if len(candidates) == 1 or not self._is_ambiguous(candidates):
+            # Clear match - save the top result
+            best_match = candidates[0]
+            administrative = (
+                self.db.query(Administrative)
+                .filter_by(id=best_match.id)
+                .first()
+            )
+            return self._save_field_value(
+                customer, administrative, field_config
+            )
+
+        # Multiple ambiguous matches - show options
+        return self._handle_ambiguous_match(customer, candidates, field_config)
 
     def _save_field_value(
         self,

--- a/backend/tests/test_onboarding_service.py
+++ b/backend/tests/test_onboarding_service.py
@@ -395,13 +395,13 @@ class TestOnboardingService:
 
         assert onboarding_service._is_ambiguous(candidates) is True
 
-    def test_is_ambiguous_false_high_confidence(
+    def test_is_ambiguous_true_high_confidence_close_scores(
         self, db_session, onboarding_service
     ):
-        """Test high confidence scores auto-select without candidates"""
+        """Test high confidence but close scores are still ambiguous"""
         from schemas.onboarding_schemas import MatchCandidate
 
-        # Score >= 90 should auto-select even if second is within 15 points
+        # Score >= 90 but within 15 points of second - should be ambiguous
         candidates = [
             MatchCandidate(
                 id=1,
@@ -416,7 +416,33 @@ class TestOnboardingService:
                 path="Path 2",
                 level="ward",
                 score=92.0,
-            ),  # Within 15 points but top is high confidence
+            ),  # Within 15 points - still ambiguous
+        ]
+
+        assert onboarding_service._is_ambiguous(candidates) is True
+
+    def test_is_ambiguous_false_high_confidence_far_apart(
+        self, db_session, onboarding_service
+    ):
+        """Test high confidence AND far apart scores auto-select"""
+        from schemas.onboarding_schemas import MatchCandidate
+
+        # Score >= 90 AND more than 15 points above second - auto-select
+        candidates = [
+            MatchCandidate(
+                id=1,
+                name="Ward 1",
+                path="Path 1",
+                level="ward",
+                score=95.0,
+            ),
+            MatchCandidate(
+                id=2,
+                name="Ward 2",
+                path="Path 2",
+                level="ward",
+                score=70.0,
+            ),  # More than 15 points apart AND top is high confidence
         ]
 
         assert onboarding_service._is_ambiguous(candidates) is False

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -58,11 +58,13 @@ trans: Dict[str, Any] = {
             "question": {
                 "en": (
                     "I need to know your location.\n\n"
-                    "Please tell me: Which ward are you from?"
+                    "Please tell me your district and ward.\n"
+                    "For example: Njoro, Lare"
                 ),
                 "sw": (
                     "Ninahitaji kujua eneo lako.\n\n"
-                    "Tafadhali niambie: Unatoka wadi gani?"
+                    "Tafadhali niambie wilaya na kata yako.\n"
+                    "Mfano: Njoro, Lare"
                 ),
             },
             "success": {
@@ -82,16 +84,38 @@ trans: Dict[str, Any] = {
                     "n.k.)"
                 ),
             },
-            "no_match": {
+            "filtered_matches": {
                 "en": (
-                    "I couldn't find a matching location for '{input}'. Could "
-                    "you please provide your location more specifically? "
-                    "Include your region, district, and ward."
+                    "I found these locations matching '{input}':\n\n{options}"
+                    "\n\nReply with the number (e.g., '1', '2', etc.)"
                 ),
                 "sw": (
-                    "Sikuweza kupata eneo linalingana na '{input}'. Tafadhali "
-                    "toa eneo lako kwa undani zaidi? Jumuisha mkoa, wilaya, "
-                    "na kata yako."
+                    "Nimepata maeneo haya yanayolingana na '{input}':\n\n"
+                    "{options}\n\nJibu kwa namba (mfano, '1', '2', n.k.)"
+                ),
+            },
+            "no_filter_match": {
+                "en": (
+                    "I couldn't find '{input}' in the options. "
+                    "Please select from:\n\n{options}\n\n"
+                    "Reply with the number (e.g., '1', '2', etc.)"
+                ),
+                "sw": (
+                    "Sikuweza kupata '{input}' katika chaguo. "
+                    "Tafadhali chagua kutoka:\n\n{options}\n\n"
+                    "Jibu kwa namba (mfano, '1', '2', n.k.)"
+                ),
+            },
+            "no_match": {
+                "en": (
+                    "I couldn't find a matching location for '{input}'. "
+                    "Please tell me your district and ward.\n"
+                    "For example: Njoro, Lare"
+                ),
+                "sw": (
+                    "Sikuweza kupata eneo linalingana na '{input}'. "
+                    "Tafadhali niambie wilaya na kata yako.\n"
+                    "Mfano: Njoro, Lare"
                 ),
             },
             "no_location_extracted_max": {
@@ -109,15 +133,13 @@ trans: Dict[str, Any] = {
             "no_location_extracted_retry": {
                 "en": (
                     "I couldn't identify your location from that message"
-                    "{attempt_msg}. Could you please tell me your "
-                    "province/region, district, and ward? For example: "
-                    "'I'm in Nairobi Region, Central District, Westlands Ward'"
+                    "{attempt_msg}. Please tell me your district and ward.\n"
+                    "For example: Njoro, Lare"
                 ),
                 "sw": (
                     "Sikuweza kutambua eneo lako kutoka ujumbe huo"
-                    "{attempt_msg}. Tafadhali niambie mkoa/eneo lako, wilaya, "
-                    "na kata? Mfano: 'Niko Mkoa wa Nairobi, Wilaya ya Kati, "
-                    "Kata ya Westlands'"
+                    "{attempt_msg}. Tafadhali niambie wilaya na kata yako.\n"
+                    "Mfano: Njoro, Lare"
                 ),
             },
             "no_matches_max": {
@@ -135,14 +157,14 @@ trans: Dict[str, Any] = {
             },
             "no_matches_retry": {
                 "en": (
-                    "I couldn't find a matching location for '{input}'. Could "
-                    "you please provide your location more specifically? "
-                    "Include your region, district, and ward."
+                    "I couldn't find a matching location for '{input}'. "
+                    "Please tell me your district and ward.\n"
+                    "For example: Njoro, Lare"
                 ),
                 "sw": (
-                    "Sikuweza kupata eneo linalingana na '{input}'. Tafadhali "
-                    "toa eneo lako kwa undani zaidi? Jumuisha mkoa, wilaya, "
-                    "na kata yako."
+                    "Sikuweza kupata eneo linalingana na '{input}'. "
+                    "Tafadhali niambie wilaya na kata yako.\n"
+                    "Mfano: Njoro, Lare"
                 ),
             },
             # Hierarchical selection messages


### PR DESCRIPTION
- Update location question to ask for "District, Ward" format
- Lower match threshold from 60% to 30% to show more options
- Auto-select only when top score is 90%+ AND >15 points above second
- When user types text instead of number during selection, do fresh database search instead of filtering existing candidates
- Add i18n messages for filtered matches and no filter match

closing #157 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214389617905313