### PR TITLE
[#159] Add validation for crop calendar support in weather advisory

### DIFF
--- a/backend/config.template.json
+++ b/backend/config.template.json
@@ -73,7 +73,7 @@
 			"log_usage": true
 		}
 	},
-	"crop_types": ["Avocado", "Potato"],
+	"crop_types": ["Avocado", "Potato", "Dairy"],
 	"contact_info": {
 		"name": "Admin",
 		"phone_number": "+1234567891"

--- a/backend/services/weather_advisory_service.py
+++ b/backend/services/weather_advisory_service.py
@@ -68,6 +68,20 @@ class WeatherAdvisoryService:
                 self._calendar_cache[crop] = {"monthly_calendar": {}}
         return self._calendar_cache[crop]
 
+    def has_calendar_support(self, crop: str) -> bool:
+        """
+        Check if a crop has calendar/rules file support.
+
+        Args:
+            crop: Crop type (e.g., "avocado", "dairy")
+
+        Returns:
+            True if crop calendar file exists
+        """
+        crop = crop.lower()
+        calendar_file = DATA_DIR / f"{crop}_crop_calendar.json"
+        return calendar_file.exists()
+
     def get_growth_stage(
         self, month: int, crop: str = "avocado", variety: str = None
     ) -> dict:

--- a/backend/services/weather_broadcast_service.py
+++ b/backend/services/weather_broadcast_service.py
@@ -114,6 +114,41 @@ class WeatherBroadcastService:
 
         return has_weather_key and has_openai and is_enabled
 
+    def _format_weather_for_generic(self, parsed_weather: dict) -> str:
+        """Format parsed weather data for generic (non-crop) template."""
+        lines = []
+
+        # Current conditions
+        temp_min = parsed_weather.get("temperature_min_c")
+        temp_max = parsed_weather.get("temperature_max_c")
+        if temp_min and temp_max:
+            lines.append(f"Temperature: {temp_min}-{temp_max}°C")
+
+        humidity = parsed_weather.get("relative_humidity_pct")
+        if humidity:
+            lines.append(f"Humidity: {humidity}%")
+
+        rain_today = parsed_weather.get("qpf_today_mm")
+        if rain_today is not None:
+            lines.append(f"Rain today: {rain_today}mm")
+
+        # Weekly forecast
+        forecast_days = parsed_weather.get("forecast_days", [])
+        if forecast_days:
+            lines.append("\nWeek ahead:")
+            for day in forecast_days[:5]:
+                date = day.get("date", "")[-5:]  # Just MM-DD
+                rain = day.get("qpf_mm", 0)
+                t_max = day.get("temperature_max_c", "?")
+                t_min = day.get("temperature_min_c", "?")
+                lines.append(f"  {date}: {t_min}-{t_max}°C, {rain}mm")
+
+        total_rain = parsed_weather.get("forecast_total_rainfall_mm")
+        if total_rain:
+            lines.append(f"\nTotal expected rain: {total_rain}mm")
+
+        return "\n".join(lines)
+
     def get_forecast_raw(self, location: str) -> Optional[Dict[str, Any]]:
         """
         Get raw weather forecast data for a location.
@@ -290,50 +325,8 @@ class WeatherBroadcastService:
         month = datetime.now().month
         crop = (farmer_crop or "avocado").lower()
 
-        # Evaluate rules (for ALL varieties)
-        triggered_rules = advisory_service.evaluate_rules(
-            weather_data=parsed_weather,
-            crop=crop,
-            variety=None,
-            month=month,
-        )
-
-        logger.info(
-            f"Weather advisory for {location} ({crop}, all varieties): "
-            f"{len(triggered_rules)} rules triggered"
-        )
-
-        # Build advisory data for LLM (includes all varieties)
-        advisory_data = advisory_service.build_advisory_data(
-            triggered_rules=triggered_rules,
-            weather_data=parsed_weather,
-            location=location,
-            crop=crop,
-            language=language,
-        )
-
-        # Load advisory prompt template
-        template_path = (
-            Path(__file__).parent.parent / "templates" / "advisory_prompt.txt"
-        )
-
-        try:
-            with open(template_path, "r") as f:
-                template_content = f.read()
-        except Exception as e:
-            logger.error(f"✗ Failed to load advisory template: {e}")
-            # Fallback to old template if advisory template not found
-            template_content = self._load_prompt_template()
-            if template_content is None:
-                return None
-
-        # Render prompt with advisory data
-        template = Template(template_content)
-        prompt = template.render(
-            advisory_data=advisory_data,
-            language=language,
-            farmer_crop=farmer_crop or "avocado",
-        )
+        # Check if crop has calendar support
+        has_calendar = advisory_service.has_calendar_support(crop)
 
         # Generate message using OpenAI
         openai_service = get_openai_service()
@@ -341,17 +334,103 @@ class WeatherBroadcastService:
             logger.error("✗ OpenAI service not configured")
             return None
 
+        if has_calendar:
+            # Use crop-specific advisory flow
+            triggered_rules = advisory_service.evaluate_rules(
+                weather_data=parsed_weather,
+                crop=crop,
+                variety=None,
+                month=month,
+            )
+
+            logger.info(
+                f"Weather advisory for {location} ({crop}, all varieties): "
+                f"{len(triggered_rules)} rules triggered"
+            )
+
+            # Build advisory data for LLM (includes all varieties)
+            advisory_data = advisory_service.build_advisory_data(
+                triggered_rules=triggered_rules,
+                weather_data=parsed_weather,
+                location=location,
+                crop=crop,
+                language=language,
+            )
+
+            # Load advisory prompt template
+            template_path = (
+                Path(__file__).parent.parent
+                / "templates"
+                / "advisory_prompt.txt"
+            )
+
+            try:
+                with open(template_path, "r") as f:
+                    template_content = f.read()
+            except Exception as e:
+                logger.error(f"✗ Failed to load advisory template: {e}")
+                template_content = self._load_prompt_template()
+                if template_content is None:
+                    return None
+
+            # Render prompt with advisory data
+            template = Template(template_content)
+            prompt = template.render(
+                advisory_data=advisory_data,
+                language=language,
+                farmer_crop=farmer_crop or "avocado",
+            )
+
+            system_message = (
+                "You are an expert agricultural weather advisor "
+                "for farmers in Kenya. Generate clear, actionable "
+                "weather advisories based on agronomic rules."
+            )
+            triggered_count = len(triggered_rules)
+        else:
+            # Use generic weather template for crops without calendar support
+            logger.info(
+                f"No calendar support for {crop}, "
+                f"using generic weather advisory"
+            )
+
+            # Load generic weather template
+            template_path = (
+                Path(__file__).parent.parent
+                / "templates"
+                / "generic_weather_prompt.txt"
+            )
+
+            try:
+                with open(template_path, "r") as f:
+                    template_content = f.read()
+            except Exception as e:
+                logger.error(f"✗ Failed to load generic template: {e}")
+                return None
+
+            # Format weather data for generic template
+            weather_data_str = self._format_weather_for_generic(parsed_weather)
+
+            # Render prompt with weather data
+            template = Template(template_content)
+            prompt = template.render(
+                weather_data=weather_data_str,
+                location=location,
+                language=language,
+                farmer_type=farmer_crop or "general",
+            )
+
+            system_message = (
+                "You are a friendly weather advisor for farmers in Kenya. "
+                "Generate clear, practical weather updates without "
+                "crop-specific farming advice."
+            )
+            triggered_count = 0
+
         try:
             response = await openai_service.chat_completion(
                 messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are an expert agricultural weather advisor "
-                            "for farmers in Kenya. Generate clear, actionable "
-                            "weather advisories based on agronomic rules."
-                        ),
-                    },
+                    {"role": "system", "content": system_message},
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.7,
@@ -360,10 +439,17 @@ class WeatherBroadcastService:
 
             if response and response.content:
                 message = response.content.strip()
-                logger.info(
-                    f"✓ Generated advisory for {location} (all varieties): "
-                    f"{len(message)} chars, {len(triggered_rules)} rules"
-                )
+                if has_calendar:
+                    logger.info(
+                        f"✓ Generated advisory for {location} "
+                        f"(all varieties): {len(message)} chars, "
+                        f"{triggered_count} rules"
+                    )
+                else:
+                    logger.info(
+                        f"✓ Generated generic weather for {location} "
+                        f"({crop}): {len(message)} chars"
+                    )
                 return message
 
             logger.error("✗ OpenAI returned empty response")

--- a/backend/templates/generic_weather_prompt.txt
+++ b/backend/templates/generic_weather_prompt.txt
@@ -1,0 +1,35 @@
+You are a friendly {{ farmer_type }} farmer neighbor in Kenya giving weather advice over WhatsApp.
+Sound like a knowledgeable friend, NOT a manual or system.
+
+LANGUAGE: {{ language }}
+{% if language == "sw" %}Write the entire message in Swahili.{% else %}Write the entire message in English.{% endif %}
+
+WEATHER DATA:
+{{ weather_data }}
+
+LOCATION: {{ location }}
+FARMER TYPE: {{ farmer_type }}
+
+RULES:
+- Use ONLY the weather data above. Do not invent statistics.
+- Give advice relevant to {{ farmer_type }} farming/activities.
+- DO NOT give crop calendar advice (no spraying schedules, fertilizer timing, pest calendars).
+- Include:
+  * Weather conditions (rain, temperature, humidity)
+  * Weather warnings if applicable (heavy rain, extreme heat, strong winds)
+  * General advice relevant to {{ farmer_type }}:
+    - For Dairy: heat stress for cattle, water needs, shelter from rain
+    - For Poultry: ventilation in heat, protecting from rain
+    - For other livestock: general animal welfare in weather conditions
+    - For unknown: general outdoor activity planning
+
+FORMAT:
+- WhatsApp: *single asterisk* for bold
+- Max 400 characters
+- Structure:
+  *Location*
+  *Today* - weather summary + relevant advice
+  *This week:* brief outlook
+
+OUTPUT:
+Write ONLY the WhatsApp message in {% if language == "sw" %}SWAHILI{% else %}ENGLISH{% endif %}.


### PR DESCRIPTION
## Summary

- Add validation to detect crops without calendar support (e.g., Dairy, Poultry)
- Generate generic weather-only advisory for unsupported crops instead of crop-specific advice
- Prevents LLM from hallucinating irrelevant crop advice like "Apply CAN fertilizer" for dairy farmers

## Changes

- **WeatherAdvisoryService**: Add `has_calendar_support()` method to check if crop calendar file exists
- **WeatherBroadcastService**: Add `_format_weather_for_generic()` helper and branch `generate_message()` based on calendar availability
- **generic_weather_prompt.txt**: New template for weather-only advisories with livestock-specific guidance

## Expected Behavior

| Farmer Type | Has Calendar | Advisory Type |
|-------------|--------------|---------------|
| Avocado | ✅ | Crop-specific with spray windows, fertilizer timing |
| Potato | ✅ | Crop-specific with hilling, blight alerts |
| Dairy | ❌ | Generic weather with cattle welfare advice |
| Poultry | ❌ | Generic weather with ventilation/shelter advice |

## Test plan

- [x] Run flake8 linter - passes
- [x] Run weather broadcast service tests - 25 passed
- [x] Manual verification of `has_calendar_support()` method
- [x] Manual verification of `_format_weather_for_generic()` output
- [ ] Integration test via WhatsApp with Dairy farmer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214440640477474