### PR TITLE
[#168] Show EO phone numbers in escalation confirmation message

### DIFF
--- a/backend/routers/whatsapp.py
+++ b/backend/routers/whatsapp.py
@@ -32,6 +32,8 @@ from services.socketio_service import emit_message_received
 from services.onboarding_service import get_onboarding_service
 from services.openai_service import get_openai_service
 from services.follow_up_service import get_follow_up_service
+from services.administrative_service import AdministrativeService
+from utils.i18n import t
 from schemas.callback import TwilioStatusCallback, TwilioMessageStatus
 from models.broadcast import BroadcastRecipient
 from tasks.broadcast_tasks import send_actual_message
@@ -201,8 +203,6 @@ async def whatsapp_webhook(
         # ========================================
         # ACCOUNT DELETION FLOW
         # ========================================
-        from utils.i18n import t
-
         # Define delete keywords (in supported languages)
         delete_keywords = ["delete", "futa"]
         # Define confirmation responses (in supported languages)
@@ -269,8 +269,6 @@ async def whatsapp_webhook(
             and not customer.data_consent_given
             and customer.language is not None
         ):
-            from utils.i18n import t
-
             whatsapp_service = WhatsAppService()
             lang = customer.language.value
 
@@ -366,8 +364,6 @@ async def whatsapp_webhook(
                     lang = (
                         customer.language.value if customer.language else "en"
                     )
-                    from utils.i18n import t
-
                     area_name = customer.customer_administrative[
                         0
                     ].administrative.name
@@ -543,7 +539,6 @@ async def whatsapp_webhook(
             from services.weather_subscription_service import (
                 get_weather_subscription_service,
             )
-            from utils.i18n import t
 
             weather_service = get_weather_subscription_service(db)
             lang = customer.language.value if customer.language else "en"
@@ -701,6 +696,46 @@ async def whatsapp_webhook(
                         customer_id=customer.id,
                     )
                 )
+
+            # Send escalation confirmation message to customer
+            # with extension officer phone numbers
+            whatsapp_service = WhatsAppService()
+            customer_lang = (
+                customer.language.value if customer.language else "en"
+            )
+            eo_list = AdministrativeService.get_extension_officers_for_area(
+                db=db,
+                administrative_id=ward_id,
+                min_count=2,
+                randomize=True,
+            )
+
+            if eo_list:
+                # Format EO contacts (name: phone_number)
+                eo_contacts = "\n".join(
+                    [f"- {eo.full_name}: {eo.phone_number}" for eo in eo_list]
+                )
+                confirmation_msg = t(
+                    "escalation.confirmed",
+                    customer_lang,
+                    eo_contacts=eo_contacts,
+                )
+            else:
+                # No EOs found, send message without contacts
+                confirmation_msg = t(
+                    "escalation.confirmed_no_contacts",
+                    customer_lang,
+                )
+
+            # Send WhatsApp message to customer
+            whatsapp_service.send_message(
+                to_number=customer.phone_number,
+                message_body=confirmation_msg,
+            )
+            logger.info(
+                f"Sent escalation confirmation to {customer.phone_number} "
+                f"with {len(eo_list)} EO contacts"
+            )
 
             return {"status": "success", "message": "Escalation processed"}
 

--- a/backend/services/administrative_service.py
+++ b/backend/services/administrative_service.py
@@ -1,3 +1,4 @@
+import random
 from typing import List
 
 from fastapi import HTTPException, status
@@ -5,6 +6,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from models import Administrative, AdministrativeLevel, UserAdministrative
+from models.user import User, UserType
 from schemas.administrative import (
     AdministrativeAssign,
     AdministrativeCreate,
@@ -305,3 +307,62 @@ class AdministrativeService:
                 break
 
         return ancestors
+
+    @staticmethod
+    def get_extension_officers_for_area(
+        db: Session,
+        administrative_id: int,
+        min_count: int = 2,
+        randomize: bool = True,
+    ) -> List[User]:
+        """
+        Get extension officers assigned to an administrative area
+        or its ancestor areas (region/district).
+
+        Args:
+            db: Database session
+            administrative_id: ID of the administrative area (ward)
+            min_count: Minimum number of officers to return
+            randomize: Whether to shuffle and select randomly
+
+        Returns:
+            List of User objects (extension officers) with phone numbers.
+            Returns up to min_count officers if randomize is True,
+            otherwise returns all matching officers.
+        """
+        # Get all administrative IDs to check
+        # (this area + ancestors like region/district)
+        area_ids = [administrative_id]
+        ancestor_ids = AdministrativeService.get_ancestor_ids(
+            db, administrative_id
+        )
+        area_ids.extend(ancestor_ids)
+
+        # Query extension officers assigned to these areas
+        officers = (
+            db.query(User)
+            .join(UserAdministrative, User.id == UserAdministrative.user_id)
+            .filter(
+                UserAdministrative.administrative_id.in_(area_ids),
+                User.user_type == UserType.EXTENSION_OFFICER,
+                User.is_active == True,  # noqa: E712
+                User.phone_number.isnot(None),
+            )
+            .distinct()
+            .all()
+        )
+
+        if not officers:
+            return []
+
+        if randomize and len(officers) > min_count:
+            # Shuffle and return min_count officers
+            return random.sample(officers, min_count)
+        elif randomize and len(officers) <= min_count:
+            # Return all available officers (shuffled)
+            shuffled = list(officers)
+            random.shuffle(shuffled)
+            return shuffled
+        else:
+            # Return all officers without shuffling
+            return officers

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -532,6 +532,30 @@ trans: Dict[str, Any] = {
             ),
         },
     },
+    "escalation": {
+        "confirmed": {
+            "en": (
+                "Your issue has been transferred to extension service "
+                "provider. Please wait for a response from them. "
+                "For urgent issues please call:\n{eo_contacts}"
+            ),
+            "sw": (
+                "Tatizo lako limehamishwa kwa mtoa huduma wa ugani. "
+                "Tafadhali subiri jibu kutoka kwao. "
+                "Kwa masuala ya dharura tafadhali piga simu:\n{eo_contacts}"
+            ),
+        },
+        "confirmed_no_contacts": {
+            "en": (
+                "Your issue has been transferred to extension service "
+                "provider. Please wait for a response from them."
+            ),
+            "sw": (
+                "Tatizo lako limehamishwa kwa mtoa huduma wa ugani. "
+                "Tafadhali subiri jibu kutoka kwao."
+            ),
+        },
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- When a farmer escalates an issue, send a WhatsApp confirmation message with extension officer contact numbers
- Selects at least 2 EOs randomly from the farmer's area or ancestor regions/districts
- Includes English and Swahili translations

## Test plan
- [ ] Escalate an issue as a farmer and verify confirmation message is received
- [ ] Verify EO phone numbers are displayed correctly
- [ ] Test when no EOs are available in the area

Closes #168

🤖 Generated with [Claude Code](https://claude.ai/code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213098163284658