### PR TITLE
[#172] Add 'Other' option to fuzzy matching location selection

### DIFF
--- a/backend/services/onboarding_service.py
+++ b/backend/services/onboarding_service.py
@@ -1605,14 +1605,19 @@ Birth year must be between 1900 and {current_year}."""
         # Get customer language
         lang = customer.language.value if customer.language else "en"
 
-        # Build options message
+        # Build options message with numbered candidates
         options_text = "\n".join(
             [f"{i+1}. {c.path}" for i, c in enumerate(top_candidates)]
         )
 
+        # Add "Other" option for step-by-step selection
+        other_option_num = len(top_candidates) + 1
+        other_option_text = t("onboarding.administration.other_option", lang)
+        options_text += f"\n{other_option_num}. {other_option_text}"
+
         logger.info(
             f"Ambiguous match for {field_name}, "
-            f"presenting {len(top_candidates)} options"
+            f"presenting {len(top_candidates)} options + Other"
         )
 
         return OnboardingResponse(
@@ -1661,12 +1666,31 @@ Birth year must be between 1900 and {current_year}."""
                 attempts=self._get_attempts(customer, field_name),
             )
 
+        # Check if user selected "Other" option (hierarchical selection)
+        is_other = selection_index == len(candidate_ids)
+        if is_other and field_name == "administration":
+            logger.info(
+                f"User selected 'Other' option, starting hierarchical "
+                f"selection for customer {customer.id}"
+            )
+            # Clear stored candidates before starting hierarchical selection
+            self._clear_field_state(customer, field_name)
+            self.db.commit()
+            return self._start_hierarchical_selection(customer)
+
+        # Check if selection is out of valid range
+        # Valid range: 0 to len(candidate_ids)-1 for actual candidates
+        # len(candidate_ids) is "Other" option (handled above for admin)
         if selection_index >= len(candidate_ids):
+            # For administration, include "Other" option in max count
+            max_options = len(candidate_ids)
+            if field_name == "administration":
+                max_options = len(candidate_ids) + 1  # Include "Other"
             return OnboardingResponse(
                 message=t(
                     "onboarding.common.selection_out_of_range",
                     lang,
-                    max=len(candidate_ids),
+                    max=max_options,
                 ),
                 status="awaiting_selection",
                 attempts=self._get_attempts(customer, field_name),

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -223,6 +223,10 @@ trans: Dict[str, Any] = {
                     "Niruhusu kuhifadhi eneo lako kama {parent}."
                 ),
             },
+            "other_option": {
+                "en": "Other (select step by step)",
+                "sw": "Nyingine (chagua hatua kwa hatua)",
+            },
             "location_saved": {
                 "en": (
                     "Thank you! I've recorded your location as: {value}. How "


### PR DESCRIPTION
## Summary
- Add "Other" option to fuzzy matching location candidates
- When selected, triggers step-by-step hierarchical selection (county → sub-county → ward)
- Supports both English and Swahili translations

Closes #172

## Test plan
- [ ] Verify fuzzy matching shows "Other" as the last option
- [ ] Test selecting "Other" triggers hierarchical selection flow
- [ ] Verify Swahili translation displays correctly
- [ ] Run backend tests (`pytest tests/test_generic_onboarding.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215153967184439