### PR TITLE
[#174] Enable EOs to receive images from customers via WhatsApp

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -14,7 +14,7 @@ module.exports = {
   expo: {
     name: getAppName(),
     slug: "agriconnect",
-    version: "1.3.7",
+    version: "1.4.0",
     owner: "akvo",
     orientation: "portrait",
     icon: "./assets/images/icon.png",

--- a/app/components/chat/message-bubble.tsx
+++ b/app/components/chat/message-bubble.tsx
@@ -17,6 +17,8 @@ import { Message } from "@/utils/chat";
 import { formatMessageTimestamp } from "@/utils/time";
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_AGRICONNECT_SERVER_URL || "";
+// Strip /api suffix for media URLs (media is served from root, not /api)
+const MEDIA_BASE_URL = API_BASE_URL.replace(/\/api\/?$/, "");
 
 interface MessageBubbleProps {
   message: Message;
@@ -24,13 +26,16 @@ interface MessageBubbleProps {
 
 const MessageBubble = ({ message }: MessageBubbleProps) => {
   const isUser = message.sender === "user";
+  // Check if this is an image message (either has media_type IMAGE or body is [Image])
   const isImage = message.media_type === "IMAGE" && message.media_url;
+  const isImagePending =
+    !isImage && message.text === "[Image]" && message.media_type !== "IMAGE";
   const [imageModalVisible, setImageModalVisible] = useState(false);
   const [imageLoading, setImageLoading] = useState(true);
   const screenWidth = Dimensions.get("window").width;
 
-  // Build full image URL
-  const imageUrl = isImage ? `${API_BASE_URL}${message.media_url}` : null;
+  // Build full image URL (media served from root, not /api)
+  const imageUrl = isImage ? `${MEDIA_BASE_URL}${message.media_url}` : null;
 
   // Render image content
   const renderImageContent = () => {
@@ -47,15 +52,16 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
           <View style={styles.imageContainer}>
             {imageLoading && (
               <View style={styles.imageLoadingOverlay}>
-                <ActivityIndicator size="small" color={themeColors.dark3} />
+                <ActivityIndicator size="large" color={themeColors["green-500"]} />
               </View>
             )}
             <Image
               source={{ uri: imageUrl }}
-              style={styles.messageImage}
+              style={[styles.messageImage, imageLoading && { opacity: 0 }]}
               resizeMode="cover"
               onLoadStart={() => setImageLoading(true)}
               onLoadEnd={() => setImageLoading(false)}
+              onError={() => setImageLoading(false)}
             />
           </View>
         </TouchableOpacity>
@@ -115,6 +121,12 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
         <View style={[styles.bubbleLeftCustomer]}>
           {isImage ? (
             renderImageContent()
+          ) : isImagePending ? (
+            <View style={styles.imageContainer}>
+              <View style={styles.imageLoadingOverlay}>
+                <ActivityIndicator size="large" color={themeColors["green-500"]} />
+              </View>
+            </View>
           ) : (
             <Text style={typography.body3}>{message.text}</Text>
           )}

--- a/app/components/chat/message-bubble.tsx
+++ b/app/components/chat/message-bubble.tsx
@@ -1,5 +1,14 @@
-import React from "react";
-import { Text, View, StyleSheet } from "react-native";
+import React, { useState } from "react";
+import {
+  Text,
+  View,
+  StyleSheet,
+  Image,
+  TouchableOpacity,
+  Modal,
+  Dimensions,
+  ActivityIndicator,
+} from "react-native";
 import Avatar from "@/components/avatar";
 import typography from "@/styles/typography";
 import themeColors from "@/styles/colors";
@@ -7,12 +16,75 @@ import { initialsFromName } from "@/utils/string";
 import { Message } from "@/utils/chat";
 import { formatMessageTimestamp } from "@/utils/time";
 
+const API_BASE_URL = process.env.EXPO_PUBLIC_AGRICONNECT_SERVER_URL || "";
+
 interface MessageBubbleProps {
   message: Message;
 }
 
 const MessageBubble = ({ message }: MessageBubbleProps) => {
   const isUser = message.sender === "user";
+  const isImage = message.media_type === "IMAGE" && message.media_url;
+  const [imageModalVisible, setImageModalVisible] = useState(false);
+  const [imageLoading, setImageLoading] = useState(true);
+  const screenWidth = Dimensions.get("window").width;
+
+  // Build full image URL
+  const imageUrl = isImage ? `${API_BASE_URL}${message.media_url}` : null;
+
+  // Render image content
+  const renderImageContent = () => {
+    if (!isImage || !imageUrl) {
+      return null;
+    }
+
+    return (
+      <>
+        <TouchableOpacity
+          onPress={() => setImageModalVisible(true)}
+          activeOpacity={0.8}
+        >
+          <View style={styles.imageContainer}>
+            {imageLoading && (
+              <View style={styles.imageLoadingOverlay}>
+                <ActivityIndicator size="small" color={themeColors.dark3} />
+              </View>
+            )}
+            <Image
+              source={{ uri: imageUrl }}
+              style={styles.messageImage}
+              resizeMode="cover"
+              onLoadStart={() => setImageLoading(true)}
+              onLoadEnd={() => setImageLoading(false)}
+            />
+          </View>
+        </TouchableOpacity>
+
+        <Modal
+          visible={imageModalVisible}
+          transparent={true}
+          animationType="fade"
+          onRequestClose={() => setImageModalVisible(false)}
+        >
+          <TouchableOpacity
+            style={styles.modalOverlay}
+            activeOpacity={1}
+            onPress={() => setImageModalVisible(false)}
+          >
+            <Image
+              source={{ uri: imageUrl }}
+              style={{
+                width: screenWidth - 40,
+                height: screenWidth - 40,
+                borderRadius: 8,
+              }}
+              resizeMode="contain"
+            />
+          </TouchableOpacity>
+        </Modal>
+      </>
+    );
+  };
 
   if (isUser) {
     return (
@@ -41,7 +113,11 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
       <Avatar initials={initialsFromName(message?.name)} size={40} />
       <View style={[styles.bubble]}>
         <View style={[styles.bubbleLeftCustomer]}>
-          <Text style={typography.body3}>{message.text}</Text>
+          {isImage ? (
+            renderImageContent()
+          ) : (
+            <Text style={typography.body3}>{message.text}</Text>
+          )}
         </View>
         <View style={styles.footer}>
           <Text style={[typography.body4, styles.timestampSecondary]}>
@@ -128,6 +204,35 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     marginBottom: 4,
     alignSelf: "flex-end",
+  },
+  imageContainer: {
+    position: "relative",
+    width: 200,
+    height: 200,
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  messageImage: {
+    width: 200,
+    height: 200,
+    borderRadius: 8,
+  },
+  imageLoadingOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: themeColors.light3,
+    zIndex: 1,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.9)",
+    justifyContent: "center",
+    alignItems: "center",
   },
 });
 

--- a/app/contexts/WebSocketContext.tsx
+++ b/app/contexts/WebSocketContext.tsx
@@ -38,6 +38,9 @@ export interface MessageCreatedEvent {
   user_id?: number; // Present for admin/EO messages (from_source=2)
   customer_id?: number; // Present for customer messages (from_source=1)
   customer_name?: string;
+  // Media fields for images, voice messages, etc.
+  media_url?: string;
+  media_type?: string; // "TEXT" | "VOICE" | "IMAGE" | etc.
 }
 
 export interface TicketResolvedEvent {

--- a/app/database/config.ts
+++ b/app/database/config.ts
@@ -1,2 +1,2 @@
-export const DATABASE_VERSION: number = 10;
+export const DATABASE_VERSION: number = 11;
 export const DATABASE_NAME: string = "agriconnect.db";

--- a/app/database/dao/messageDAO.ts
+++ b/app/database/dao/messageDAO.ts
@@ -604,7 +604,27 @@ export class MessageDAO extends BaseDAOImpl<Message> {
       }
 
       if (existing) {
-        // Message already exists, return it without updating
+        // Message exists - update media fields if they changed
+        // This handles the case where messages were synced before media support
+        const needsMediaUpdate =
+          (data.media_url && existing.media_url !== data.media_url) ||
+          (data.media_type &&
+            data.media_type !== "TEXT" &&
+            existing.media_type !== data.media_type);
+
+        if (needsMediaUpdate) {
+          console.log(
+            `[MessageDAO] Updating media fields for message ${existing.id}: ` +
+              `media_url=${data.media_url}, media_type=${data.media_type}`,
+          );
+          this.update(db, existing.id, {
+            media_url: data.media_url,
+            media_type: data.media_type,
+          });
+          // Return updated message
+          return this.findById(db, existing.id);
+        }
+
         console.log(`[MessageDAO] Message already exists: ${existing.id}`);
         return existing;
       } else {

--- a/app/database/dao/messageDAO.ts
+++ b/app/database/dao/messageDAO.ts
@@ -46,14 +46,14 @@ export class MessageDAO extends BaseDAOImpl<Message> {
       ? db.prepareSync(
           `INSERT INTO messages (
             id, from_source, message_sid, customer_id, user_id, body,
-            message_type, status, is_used, delivery_status, createdAt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            message_type, status, is_used, delivery_status, media_url, media_type, createdAt
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
       : db.prepareSync(
           `INSERT INTO messages (
             from_source, message_sid, customer_id, user_id, body,
-            message_type, status, is_used, delivery_status, createdAt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            message_type, status, is_used, delivery_status, media_url, media_type, createdAt
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         );
 
     try {
@@ -69,6 +69,8 @@ export class MessageDAO extends BaseDAOImpl<Message> {
             data.status || 1, // Default to PENDING (1)
             data.is_used || 0, // Default to not used (0)
             data.delivery_status || DeliveryStatus.PENDING,
+            data.media_url || null,
+            data.media_type || "TEXT", // Default to TEXT
             data.createdAt,
           ]
         : [
@@ -81,6 +83,8 @@ export class MessageDAO extends BaseDAOImpl<Message> {
             data.status || 1, // Default to PENDING (1)
             data.is_used || 0, // Default to not used (0)
             data.delivery_status || DeliveryStatus.PENDING,
+            data.media_url || null,
+            data.media_type || "TEXT", // Default to TEXT
             data.createdAt,
           ];
 
@@ -157,6 +161,14 @@ export class MessageDAO extends BaseDAOImpl<Message> {
       if (data.delivery_status !== undefined) {
         updates.push("delivery_status = ?");
         values.push(data.delivery_status);
+      }
+      if (data.media_url !== undefined) {
+        updates.push("media_url = ?");
+        values.push(data.media_url);
+      }
+      if (data.media_type !== undefined) {
+        updates.push("media_type = ?");
+        values.push(data.media_type);
       }
 
       if (updates.length === 0) {

--- a/app/database/dao/types/message.ts
+++ b/app/database/dao/types/message.ts
@@ -4,6 +4,7 @@
 // Note: message_type (1=REPLY, 2=WHISPER)
 // Note: is_used (0=not used, 1=used) - tracks if WHISPER message has been accepted
 // Note: delivery_status - Twilio delivery tracking: PENDING, QUEUED, SENDING, SENT, DELIVERED, READ, FAILED, UNDELIVERED
+// Note: media_type - TEXT, VOICE, IMAGE, VIDEO, DOCUMENT, LOCATION, OTHER
 // Import from @/constants/messageSource and @/constants/messageStatus when needed
 export interface Message {
   id: number;
@@ -16,6 +17,8 @@ export interface Message {
   status: number; // 1=PENDING, 2=REPLIED, 3=RESOLVED
   is_used: number; // 0=not used, 1=used (for WHISPER messages)
   delivery_status: string; // Twilio delivery status: PENDING, QUEUED, SENDING, SENT, DELIVERED, READ, FAILED, UNDELIVERED
+  media_url: string | null; // URL to media file (images, voice, etc.)
+  media_type: string; // TEXT, VOICE, IMAGE, VIDEO, DOCUMENT, LOCATION, OTHER
   createdAt: string;
   updatedAt: string;
 }
@@ -31,6 +34,8 @@ export interface CreateMessageData {
   status?: number; // Use MessageStatus constants (default: PENDING=1)
   is_used?: number; // 0=not used, 1=used (default: 0)
   delivery_status?: string; // Twilio delivery status (default: PENDING)
+  media_url?: string | null; // URL to media file (images, voice, etc.)
+  media_type?: string; // TEXT, VOICE, IMAGE, etc. (default: TEXT)
 }
 
 export interface UpdateMessageData {
@@ -43,9 +48,12 @@ export interface UpdateMessageData {
   status?: number; // Use MessageStatus constants
   is_used?: number; // 0=not used, 1=used
   delivery_status?: string; // Twilio delivery status
+  media_url?: string | null; // URL to media file (images, voice, etc.)
+  media_type?: string; // TEXT, VOICE, IMAGE, etc.
 }
 
 // Extended message interface with user details (for inbox/conversation views)
+// Note: Inherits media_url and media_type from Message interface
 export interface MessageWithUsers extends Message {
   customer_name: string;
   customer_phone: string;

--- a/app/database/migrations/014_alter_messages_add_media.ts
+++ b/app/database/migrations/014_alter_messages_add_media.ts
@@ -1,0 +1,16 @@
+// Alter messages table to add media_url and media_type columns
+// media_url: URL to media file (images, voice messages, etc.)
+// media_type: Type of media - TEXT, VOICE, IMAGE, VIDEO, DOCUMENT, LOCATION, OTHER
+export const alterMessagesAddMediaMigration = `
+-- Add media_url column to messages table
+-- Stores relative URL path to media files (e.g., /media/abc123.jpg)
+ALTER TABLE messages ADD COLUMN media_url TEXT DEFAULT NULL;
+
+-- Add media_type column to messages table
+-- Default to 'TEXT' for existing and text-only messages
+-- This matches backend MediaType enum
+ALTER TABLE messages ADD COLUMN media_type TEXT NOT NULL DEFAULT 'TEXT';
+
+-- Create index for media_type for efficient filtering
+CREATE INDEX idx_messages_media_type ON messages(media_type);
+`;

--- a/app/database/migrations/index.ts
+++ b/app/database/migrations/index.ts
@@ -11,6 +11,7 @@ import { alterTicketsAddLastMessageIdMigration } from "./010_alter_tickets_add_l
 import { customerProfileFieldsMigration } from "./011_alter_customer_add_profile";
 import { alterTicketsAddContextMessageIdMigration } from "./012_alter_tickets_add_contextMessageId";
 import { createUserStatsMigration } from "./013_create_user_stats";
+import { alterMessagesAddMediaMigration } from "./014_alter_messages_add_media";
 
 // Type definition for migration objects
 export interface Migration {
@@ -66,6 +67,11 @@ export const allMigrations: Migration[] = [
     version: 10,
     name: "create_user_stats",
     migration: createUserStatsMigration,
+  },
+  {
+    version: 11,
+    name: "alter_messages_add_media",
+    migration: alterMessagesAddMediaMigration,
   },
 ];
 

--- a/app/hooks/chat/useChatWebSocket.ts
+++ b/app/hooks/chat/useChatWebSocket.ts
@@ -95,6 +95,8 @@ export const useChatWebSocket = ({
           user_id: event.user_id || null, // Use user_id from event for admin messages
           body: event.body,
           createdAt: event.ts,
+          media_url: event.media_url || null,
+          media_type: event.media_type || "TEXT",
         });
 
         if (savedMessage) {

--- a/app/hooks/chat/useTicketData.ts
+++ b/app/hooks/chat/useTicketData.ts
@@ -32,6 +32,8 @@ const convertToUIMessage = (
     text: msg.body,
     sender: isCustomerMessage ? "customer" : "user",
     timestamp: msg.createdAt,
+    media_url: msg.media_url || undefined,
+    media_type: msg.media_type || "TEXT",
   };
 };
 

--- a/app/services/messageSync.ts
+++ b/app/services/messageSync.ts
@@ -20,6 +20,8 @@ interface MessageResponse {
   message_type: number; // 1=REPLY, 2=WHISPER
   status: number; // 1=PENDING, 2=REPLIED, 3=RESOLVED (matches backend MessageStatus)
   delivery_status: string; // PENDING, QUEUED, SENDING, SENT, DELIVERED, READ, FAILED, UNDELIVERED
+  media_url: string | null; // URL to media file (images, voice, etc.)
+  media_type: string; // TEXT, VOICE, IMAGE, etc.
   user_id: number | null; // User ID for messages from users
   user: MessageUser | null; // User details for messages from users (from_source = USER)
   created_at: string;
@@ -121,6 +123,8 @@ class MessageSyncService {
         message_type: apiMessage.message_type,
         status: apiMessage.status || 1, // Default to PENDING if not provided
         delivery_status: apiMessage.delivery_status || DeliveryStatus.PENDING,
+        media_url: apiMessage.media_url || null,
+        media_type: apiMessage.media_type || "TEXT",
         createdAt: apiMessage.created_at,
       });
     } catch (error) {

--- a/app/utils/chat.ts
+++ b/app/utils/chat.ts
@@ -7,6 +7,8 @@ export interface Message {
   text: string;
   sender: "user" | "customer";
   timestamp: string; // ISO string or formatted date
+  media_url?: string; // URL to media file (images, voice, etc.)
+  media_type?: string; // "TEXT" | "VOICE" | "IMAGE" | "VIDEO" | "DOCUMENT"
 }
 
 const groupMessagesByDate = (messages: Message[]) => {

--- a/backend/main.py
+++ b/backend/main.py
@@ -122,6 +122,10 @@ app.include_router(statistic.router, prefix="/api")
 os.makedirs("storage", exist_ok=True)
 app.mount("/storage", StaticFiles(directory="storage"), name="storage")
 
+# Ensure media directory exists before mounting (for customer images)
+os.makedirs("media", exist_ok=True)
+app.mount("/media", StaticFiles(directory="media"), name="media")
+
 
 # Health check endpoint
 @app.get("/api/health-check", tags=["health-check"])

--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -478,6 +478,12 @@ async def get_ticket_conversation(
                 if hasattr(m, "delivery_status") and m.delivery_status
                 else "PENDING"
             ),
+            "media_url": m.media_url,
+            "media_type": (
+                m.media_type.value
+                if hasattr(m, "media_type") and m.media_type
+                else "TEXT"
+            ),
             "user_id": m.user_id,
             "user": (
                 {

--- a/backend/routers/whatsapp.py
+++ b/backend/routers/whatsapp.py
@@ -144,6 +144,74 @@ async def whatsapp_webhook(
                         )
 
         # ========================================
+        # IMAGE MESSAGE HANDLING
+        # ========================================
+        is_image = (
+            NumMedia
+            and NumMedia > 0
+            and MediaContentType0
+            and "image" in MediaContentType0
+        )
+        if is_image:
+            logger.info(
+                f"Image message received from {phone_number}: "
+                f"{MediaContentType0} at {MediaUrl0}"
+            )
+
+            media_type = MediaType.IMAGE
+
+            # Determine file extension from content type
+            ext_map = {
+                "image/jpeg": "jpg",
+                "image/jpg": "jpg",
+                "image/png": "png",
+                "image/webp": "webp",
+                "image/gif": "gif",
+            }
+            ext = ext_map.get(MediaContentType0, "jpg")
+
+            # Generate unique filename
+            unique_filename = f"{uuid.uuid4().hex}.{ext}"
+            media_dir = "/app/media"
+            save_path = os.path.join(media_dir, unique_filename)
+
+            try:
+                # Ensure media directory exists
+                os.makedirs(media_dir, exist_ok=True)
+
+                # Download image from Twilio
+                whatsapp_service = WhatsAppService()
+                downloaded_path = whatsapp_service.download_twilio_media(
+                    media_url=MediaUrl0, save_path=save_path
+                )
+
+                if downloaded_path:
+                    # Set media_url to relative path for serving
+                    media_url = f"/media/{unique_filename}"
+                    logger.info(
+                        f"✓ Image saved for {phone_number}: {media_url}"
+                    )
+                    # Set fallback body text
+                    if not Body or not Body.strip():
+                        Body = "[Image]"
+                else:
+                    # Download failed
+                    logger.error(
+                        f"✗ Failed to download image from {phone_number}"
+                    )
+                    media_url = None
+                    media_type = MediaType.TEXT
+                    if not Body or not Body.strip():
+                        Body = "[Image - download failed]"
+
+            except Exception as e:
+                logger.error(f"✗ Error downloading image: {e}")
+                media_url = None
+                media_type = MediaType.TEXT
+                if not Body or not Body.strip():
+                    Body = "[Image - download error]"
+
+        # ========================================
         # CONTINUE WITH EXISTING MESSAGE FLOW
         # (Body is now either original text or transcribed text)
         # ========================================

--- a/backend/routers/whatsapp.py
+++ b/backend/routers/whatsapp.py
@@ -762,6 +762,11 @@ async def whatsapp_webhook(
                         sender_name=sender_name,
                         sender_user_id=None,
                         customer_id=customer.id,
+                        media_url=message.media_url,
+                        media_type=(
+                            message.media_type.value
+                            if message.media_type else "TEXT"
+                        ),
                     )
                 )
 
@@ -997,6 +1002,8 @@ async def whatsapp_webhook(
                     sender_name=sender_name,
                     sender_user_id=None,
                     customer_id=customer.id,
+                    media_url=media_url,
+                    media_type=media_type.value if media_type else "TEXT",
                 )
             )
 

--- a/backend/services/socketio_service.py
+++ b/backend/services/socketio_service.py
@@ -280,6 +280,8 @@ async def emit_message_received(
     sender_name: str = None,
     sender_user_id: Optional[int] = None,
     customer_id: Optional[int] = None,
+    media_url: Optional[str] = None,
+    media_type: str = "TEXT",
 ):
     """Emit message with ticket metadata for optimistic UI display"""
     event_data = {
@@ -291,6 +293,8 @@ async def emit_message_received(
         "ts": ts,
         "ticket_number": ticket_number,
         "sender_name": sender_name,
+        "media_url": media_url,
+        "media_type": media_type,
     }
 
     # Conditional field based on sender type

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     working_dir: /app
     volumes:
       - ./backend:/app:delegated
+      - media-data:/app/media
   frontend:
     depends_on:
       - backend
@@ -120,3 +121,4 @@ services:
 volumes:
   pg-data:
   redis-data:
+  media-data:

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,12 +1,6 @@
 {
-  "extends": [
-    "next/core-web-vitals",
-    "eslint:recommended",
-    "prettier"
-  ],
-  "plugins": [
-    "prettier"
-  ],
+  "extends": ["next/core-web-vitals", "eslint:recommended", "prettier"],
+  "plugins": ["prettier"],
   "env": {
     "browser": true,
     "node": true,

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,25 +1,25 @@
-const nextJest = require('next/jest')
+const nextJest = require("next/jest");
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files
-  dir: './',
-})
+  dir: "./",
+});
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  testEnvironment: "jsdom",
   moduleNameMapper: {
     // Handle module aliases (this will be automatically configured for you based on your tsconfig.json paths)
-    '^@/(.*)$': '<rootDir>/src/$1',
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
   collectCoverageFrom: [
-    'src/**/*.{js,jsx,ts,tsx}',
-    '!src/**/*.d.ts',
-    '!src/app/globals.css',
+    "src/**/*.{js,jsx,ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/app/globals.css",
   ],
-}
+};
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig)
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom'
+import "@testing-library/jest-dom";

--- a/frontend/src/app/media/[...path]/route.js
+++ b/frontend/src/app/media/[...path]/route.js
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = "http://localhost:8000";
+
+async function handler(request, { params }) {
+  try {
+    const { path } = await params;
+    const pathString = Array.isArray(path) ? path.join("/") : path;
+    const url = `${BACKEND_URL}/media/${pathString}`;
+
+    // Get search params from the original request
+    const searchParams = request.nextUrl.searchParams;
+    const fullUrl = searchParams.toString() ? `${url}?${searchParams}` : url;
+
+    // Forward headers (skip conditional headers to avoid 304 responses)
+    const headers = new Headers();
+    request.headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase();
+      if (
+        ![
+          "host",
+          "connection",
+          "content-length",
+          "if-none-match",
+          "if-modified-since",
+        ].includes(lowerKey)
+      ) {
+        headers.set(key, value);
+      }
+    });
+
+    // Make request to backend
+    const response = await fetch(fullUrl, {
+      method: request.method,
+      headers,
+    });
+
+    // Handle 304 Not Modified specially
+    if (response.status === 304) {
+      return new NextResponse(null, {
+        status: 304,
+      });
+    }
+
+    // Get response data
+    const responseData = await response.arrayBuffer();
+
+    // Create response with same status and headers
+    const nextResponse = new NextResponse(responseData, {
+      status: response.status,
+      statusText: response.statusText,
+    });
+
+    // Forward response headers (especially content-type for static files)
+    response.headers.forEach((value, key) => {
+      nextResponse.headers.set(key, value);
+    });
+
+    return nextResponse;
+  } catch (error) {
+    console.error("Media Proxy Error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}
+
+export const GET = handler;

--- a/frontend/src/app/media/route.js
+++ b/frontend/src/app/media/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+const BACKEND_URL = "http://localhost:8000";
+
+export async function GET() {
+  try {
+    const response = await fetch(`${BACKEND_URL}/media`);
+    const html = await response.text();
+
+    return new NextResponse(html, {
+      status: response.status,
+      headers: {
+        "Content-Type": "text/html",
+      },
+    });
+  } catch (error) {
+    console.error("Media listing error:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -68,6 +68,15 @@ server {
         proxy_http_version      1.1;
     }
 
+    location /media {
+        proxy_pass              http://backend:8000;
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-Host $host;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_http_version      1.1;
+    }
+
     location / {
         proxy_pass   http://frontend:3000;
         proxy_set_header   Host             $host;


### PR DESCRIPTION
## Summary
- Add support for Extension Officers to view images sent by customers/farmers via WhatsApp in the mobile app
- Images are downloaded from Twilio, stored in `/media` directory, and served via FastAPI StaticFiles
- Mobile app renders images in chat bubbles with tap-to-expand full-screen modal

## Changes

### Backend
- Add `media-data` volume in docker-compose.yml mounted to `/app/media`
- Add StaticFiles mount for `/media` in `main.py`
- Handle image download and storage in WhatsApp webhook (`whatsapp.py`)
- Return `media_url` and `media_type` fields in tickets API (`tickets.py`)

### Mobile App
- Add `media_url` and `media_type` fields to Message interfaces
- Add database migration (v11) for media columns
- Update messageDAO to handle media fields in create/update
- Render images in chat bubble with loading indicator and full-screen modal

### Infrastructure
- Add nginx location block for `/media` path
- Add Next.js frontend routes for `/media` proxy

## Backward Compatibility
| media_type | body | Renders |
|------------|------|---------|
| TEXT | "Hello" | Text (unchanged) |
| VOICE | "transcribed text" | Text (unchanged) |
| IMAGE | "[Image]" | Image from media_url |

## Test plan
- [ ] Send image via WhatsApp to test number
- [ ] Verify image is saved in `/media` directory
- [ ] Verify `GET /api/tickets/{id}/messages` returns `media_url` and `media_type`
- [ ] Verify `GET /media/{filename}` serves the image
- [ ] Open chat in mobile app, verify image displays
- [ ] Tap image to view full-screen modal
- [ ] Verify existing text/voice messages still display correctly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212279540401807