### PR TITLE
[#176] Enable EOs to send images to customers via WhatsApp

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -14,7 +14,7 @@ module.exports = {
   expo: {
     name: getAppName(),
     slug: "agriconnect",
-    version: "1.4.0",
+    version: "1.4.1",
     owner: "akvo",
     orientation: "portrait",
     icon: "./assets/images/icon.png",

--- a/app/components/chat/chat-input.tsx
+++ b/app/components/chat/chat-input.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { View, TextInput, TouchableOpacity, StyleSheet } from "react-native";
 import Feathericons from "@expo/vector-icons/Feather";
 import { api } from "@/services/api";
@@ -10,6 +10,8 @@ import { useDatabase } from "@/database/context";
 import typography from "@/styles/typography";
 import themeColors from "@/styles/colors";
 import { useNetwork } from "@/contexts/NetworkContext";
+import { ImagePickerButton } from "./image-picker-button";
+import { ImagePreview } from "./image-preview";
 
 interface TicketData {
   id: number | null;
@@ -47,9 +49,25 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const db = useDatabase();
   const daoManager = useMemo(() => new DAOManager(db), [db]);
 
+  // Image state
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleImageSelected = (uri: string) => {
+    setSelectedImage(uri);
+  };
+
+  const handleRemoveImage = () => {
+    setSelectedImage(null);
+  };
+
   const handleSend = async () => {
+    // Allow sending if there's text OR an image
+    const hasText = text.trim().length > 0;
+    const hasImage = selectedImage !== null;
+
     if (
-      text.trim().length === 0 ||
+      (!hasText && !hasImage) ||
       !ticket?.id ||
       !ticket?.customer?.id ||
       !user?.id
@@ -57,8 +75,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       return;
     }
 
-    const messageText = text.trim();
+    const messageText = hasText ? text.trim() : "[Image]";
     setText("");
+
+    // Store selected image before clearing
+    const imageToUpload = selectedImage;
+    setSelectedImage(null);
 
     try {
       const now = new Date().toISOString();
@@ -72,6 +94,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         text: messageText,
         sender: "user",
         timestamp: now,
+        // Include image info in optimistic message if present
+        ...(imageToUpload && {
+          media_url: imageToUpload,
+          media_type: "IMAGE",
+        }),
       };
 
       // Add optimistic message to UI immediately
@@ -84,17 +111,42 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       console.log(
         `[Chat] Sending message to backend - ticket_id: ${ticket.id}, body: "${messageText}", from_source: ${MessageFrom.USER}`,
       );
+
       try {
+        let mediaUrl: string | undefined;
+        let mediaType: string | undefined;
+
+        // Upload image first if present
+        if (imageToUpload) {
+          setIsUploading(true);
+          console.log("[Chat] Uploading image...");
+          try {
+            const uploadResult = await api.uploadImage(imageToUpload);
+            mediaUrl = uploadResult.media_url;
+            mediaType = uploadResult.media_type;
+            console.log("[Chat] Image uploaded:", uploadResult);
+          } catch (uploadError) {
+            console.error("[Chat] Failed to upload image:", uploadError);
+            // Remove optimistic message on upload failure
+            setMessages((prev: Message[]) =>
+              prev.filter((msg) => msg.id !== tempId),
+            );
+            setIsUploading(false);
+            return;
+          }
+          setIsUploading(false);
+        }
+
+        // Send message with optional media
         const response = await api.sendMessage(
           ticket.id,
           messageText,
           MessageFrom.USER,
+          mediaUrl,
+          mediaType,
         );
 
-        console.log(
-          "[Chat] ✅ Message sent to backend successfully:",
-          response,
-        );
+        console.log("[Chat] Message sent to backend successfully:", response);
 
         // Save the backend message to SQLite database with the real ID and message_sid
         const savedMessage = daoManager.message.create(db, {
@@ -137,6 +189,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                   text: savedMessage.body,
                   sender: "user",
                   timestamp: savedMessage.createdAt,
+                  media_url: response.media_url,
+                  media_type: response.media_type,
                 }
               : msg,
           );
@@ -155,7 +209,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           }
         }
       } catch (apiError) {
-        console.error("❌ [Chat] Failed to send message to backend:", apiError);
+        console.error("[Chat] Failed to send message to backend:", apiError);
         console.error("[Chat] Error details:", {
           message:
             apiError instanceof Error ? apiError.message : String(apiError),
@@ -176,41 +230,68 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   };
 
+  const canSend =
+    (text.trim().length > 0 || selectedImage !== null) &&
+    isOnline &&
+    !isUploading;
+
   return (
-    <View style={styles.inputRow}>
-      <View style={styles.textInputContainer}>
-        <TextInput
-          value={text}
-          onChangeText={setText}
-          style={[
-            typography.body3,
-            styles.textInput,
-            { color: themeColors.dark3 },
-            ticket?.customer?.language &&
-              ticket?.customer?.language !== "en" && { paddingRight: 32 },
-          ]}
-          placeholder="Type a message..."
-          placeholderTextColor={themeColors.dark3}
-          multiline
+    <View style={styles.container}>
+      {/* Image preview */}
+      {selectedImage && (
+        <ImagePreview
+          imageUri={selectedImage}
+          onRemove={handleRemoveImage}
+          isUploading={isUploading}
         />
+      )}
+
+      {/* Input row */}
+      <View style={styles.inputRow}>
+        {/* Image picker button */}
+        <ImagePickerButton
+          onImageSelected={handleImageSelected}
+          disabled={!isOnline || isUploading}
+        />
+
+        <View style={styles.textInputContainer}>
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            style={[
+              typography.body3,
+              styles.textInput,
+              { color: themeColors.dark3 },
+              ticket?.customer?.language &&
+                ticket?.customer?.language !== "en" && { paddingRight: 32 },
+            ]}
+            placeholder="Type a message..."
+            placeholderTextColor={themeColors.dark3}
+            multiline
+            editable={!isUploading}
+          />
+        </View>
+        <TouchableOpacity
+          onPress={handleSend}
+          style={[styles.sendButton, !canSend && styles.sendButtonDisabled]}
+          disabled={!canSend}
+        >
+          <Feathericons name="send" size={20} color={themeColors.white} />
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        onPress={handleSend}
-        style={[styles.sendButton, !isOnline && styles.sendButtonDisabled]}
-        disabled={!isOnline}
-      >
-        <Feathericons name="send" size={20} color={themeColors.white} />
-      </TouchableOpacity>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
+  container: {
+    backgroundColor: themeColors.white,
+  },
   inputRow: {
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 8,
-    paddingHorizontal: 12,
+    paddingHorizontal: 8,
     borderTopWidth: 0,
     backgroundColor: themeColors.white,
     position: "relative",

--- a/app/components/chat/image-picker-button.tsx
+++ b/app/components/chat/image-picker-button.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { TouchableOpacity, Alert, StyleSheet } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import Feathericons from "@expo/vector-icons/Feather";
+import themeColors from "@/styles/colors";
+
+interface ImagePickerButtonProps {
+  onImageSelected: (uri: string) => void;
+  disabled?: boolean;
+}
+
+export const ImagePickerButton: React.FC<ImagePickerButtonProps> = ({
+  onImageSelected,
+  disabled = false,
+}) => {
+  const requestCameraPermission = async (): Promise<boolean> => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "Permission Required",
+        "Camera permission is required to take photos.",
+        [{ text: "OK" }],
+      );
+      return false;
+    }
+    return true;
+  };
+
+  const requestMediaLibraryPermission = async (): Promise<boolean> => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "Permission Required",
+        "Photo library permission is required to select images.",
+        [{ text: "OK" }],
+      );
+      return false;
+    }
+    return true;
+  };
+
+  const launchCamera = async () => {
+    const hasPermission = await requestCameraPermission();
+    if (!hasPermission) {
+      return;
+    }
+
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ["images"],
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      onImageSelected(result.assets[0].uri);
+    }
+  };
+
+  const launchGallery = async () => {
+    const hasPermission = await requestMediaLibraryPermission();
+    if (!hasPermission) {
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      onImageSelected(result.assets[0].uri);
+    }
+  };
+
+  const handlePress = () => {
+    if (disabled) {
+      return;
+    }
+
+    Alert.alert("Select Image", "Choose an option", [
+      { text: "Camera", onPress: launchCamera },
+      { text: "Gallery", onPress: launchGallery },
+      { text: "Cancel", style: "cancel" },
+    ]);
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      style={[styles.button, disabled && styles.buttonDisabled]}
+      disabled={disabled}
+    >
+      <Feathericons
+        name="image"
+        size={22}
+        color={disabled ? themeColors.dark4 : themeColors["green-500"]}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    padding: 8,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+});
+
+export default ImagePickerButton;

--- a/app/components/chat/image-preview.tsx
+++ b/app/components/chat/image-preview.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import {
+  View,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
+import Feathericons from "@expo/vector-icons/Feather";
+import themeColors from "@/styles/colors";
+
+interface ImagePreviewProps {
+  imageUri: string;
+  onRemove: () => void;
+  isUploading?: boolean;
+}
+
+export const ImagePreview: React.FC<ImagePreviewProps> = ({
+  imageUri,
+  onRemove,
+  isUploading = false,
+}) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.imageWrapper}>
+        <Image
+          source={{ uri: imageUri }}
+          style={styles.image}
+          resizeMode="cover"
+        />
+        {isUploading && (
+          <View style={styles.uploadingOverlay}>
+            <ActivityIndicator size="small" color={themeColors.white} />
+          </View>
+        )}
+        {!isUploading && (
+          <TouchableOpacity
+            onPress={onRemove}
+            style={styles.removeButton}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Feathericons name="x" size={14} color={themeColors.white} />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  imageWrapper: {
+    position: "relative",
+    width: 80,
+    height: 80,
+    borderRadius: 8,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: themeColors.mutedBorder,
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+  },
+  removeButton: {
+    position: "absolute",
+    top: 4,
+    right: 4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  uploadingOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});
+
+export default ImagePreview;

--- a/app/components/chat/message-bubble.tsx
+++ b/app/components/chat/message-bubble.tsx
@@ -34,11 +34,33 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
   const [imageLoading, setImageLoading] = useState(true);
   const screenWidth = Dimensions.get("window").width;
 
-  // Build full image URL (media served from root, not /api)
-  const imageUrl = isImage ? `${MEDIA_BASE_URL}${message.media_url}` : null;
+  // Build full image URL
+  // For local file URIs (optimistic uploads), use as-is
+  // For server media URLs, prepend the media base URL
+  const getImageUrl = () => {
+    if (!isImage || !message.media_url) {
+      return null;
+    }
 
-  // Render image content
-  const renderImageContent = () => {
+    // Check if it's a local file URI (optimistic upload)
+    if (
+      message.media_url.startsWith("file://") ||
+      message.media_url.startsWith("content://")
+    ) {
+      return message.media_url;
+    }
+
+    // Server media URL - prepend base URL
+    return `${MEDIA_BASE_URL}${message.media_url}`;
+  };
+
+  const imageUrl = getImageUrl();
+
+  // Check if the text is just "[Image]" placeholder (should only show image, no text)
+  const isImageOnlyMessage = message.text === "[Image]" && isImage;
+
+  // Render image content (shared between user and customer messages)
+  const renderImageContent = (forUser: boolean = false) => {
     if (!isImage || !imageUrl) {
       return null;
     }
@@ -49,10 +71,18 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
           onPress={() => setImageModalVisible(true)}
           activeOpacity={0.8}
         >
-          <View style={styles.imageContainer}>
+          <View
+            style={[
+              styles.imageContainer,
+              forUser && styles.imageContainerUser,
+            ]}
+          >
             {imageLoading && (
               <View style={styles.imageLoadingOverlay}>
-                <ActivityIndicator size="large" color={themeColors["green-500"]} />
+                <ActivityIndicator
+                  size="large"
+                  color={themeColors["green-500"]}
+                />
               </View>
             )}
             <Image
@@ -93,6 +123,10 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
   };
 
   if (isUser) {
+    // User message - check if it's an image message
+    const userIsImagePending =
+      !isImage && message.text === "[Image]" && message.media_type !== "IMAGE";
+
     return (
       <View style={[styles.messageRow, styles.rowRight]}>
         <View style={[styles.bubble]}>
@@ -100,11 +134,31 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
           <Text style={[typography.body4, styles.senderName]}>
             {message.name}
           </Text>
-          <View style={[styles.bubbleRight]}>
-            <Text style={[typography.body3, styles.userText]}>
-              {message.text}
-            </Text>
-          </View>
+
+          {/* Image content for user messages */}
+          {isImage && renderImageContent(true)}
+
+          {/* Image pending state (uploading) */}
+          {userIsImagePending && (
+            <View style={[styles.imageContainer, styles.imageContainerUser]}>
+              <View style={styles.imageLoadingOverlay}>
+                <ActivityIndicator
+                  size="large"
+                  color={themeColors["green-500"]}
+                />
+              </View>
+            </View>
+          )}
+
+          {/* Text content (caption or regular text) */}
+          {!isImageOnlyMessage && !userIsImagePending && (
+            <View style={[styles.bubbleRight]}>
+              <Text style={[typography.body3, styles.userText]}>
+                {message.text}
+              </Text>
+            </View>
+          )}
+
           <View style={styles.footer}>
             <Text style={[typography.caption1, styles.timestamp]}>
               {formatMessageTimestamp(message.timestamp)}
@@ -124,7 +178,10 @@ const MessageBubble = ({ message }: MessageBubbleProps) => {
           ) : isImagePending ? (
             <View style={styles.imageContainer}>
               <View style={styles.imageLoadingOverlay}>
-                <ActivityIndicator size="large" color={themeColors["green-500"]} />
+                <ActivityIndicator
+                  size="large"
+                  color={themeColors["green-500"]}
+                />
               </View>
             </View>
           ) : (
@@ -223,6 +280,9 @@ const styles = StyleSheet.create({
     height: 200,
     borderRadius: 8,
     overflow: "hidden",
+  },
+  imageContainerUser: {
+    alignSelf: "flex-end",
   },
   messageImage: {
     width: 200,

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
 		"expo-font": "~14.0.8",
 		"expo-haptics": "~15.0.7",
 		"expo-image": "~3.0.8",
+		"expo-image-picker": "~17.0.11",
 		"expo-linking": "~8.0.8",
 		"expo-notifications": "^0.32.12",
 		"expo-router": "~6.0.8",

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -380,13 +380,27 @@ class ApiClient {
     ticketId: number,
     body: string,
     fromSource: number,
+    mediaUrl?: string,
+    mediaType?: string,
   ): Promise<any> {
     const url = `${this.baseUrl}/messages`;
-    const payload = {
+    const payload: {
+      ticket_id: number;
+      body: string;
+      from_source: number;
+      media_url?: string;
+      media_type?: string;
+    } = {
       ticket_id: ticketId,
       body,
       from_source: fromSource,
     };
+
+    // Add media fields if provided
+    if (mediaUrl) {
+      payload.media_url = mediaUrl;
+      payload.media_type = mediaType || "IMAGE";
+    }
 
     console.log("[API] Sending message:", {
       url,
@@ -414,6 +428,53 @@ class ApiClient {
 
     const responseData = await response.json();
     console.log("[API] Success response:", responseData);
+    return responseData;
+  }
+
+  /**
+   * Upload an image for sending via WhatsApp
+   * @param imageUri Local file URI (e.g., file:///path/to/image.jpg)
+   * @returns Object with media_url and media_type
+   */
+  async uploadImage(imageUri: string): Promise<{
+    media_url: string;
+    media_type: string;
+  }> {
+    const url = `${this.baseUrl}/messages/upload-image`;
+
+    // Get filename and type from URI
+    const filename = imageUri.split("/").pop() || "image.jpg";
+    const match = /\.(\w+)$/.exec(filename);
+    const type = match ? `image/${match[1].toLowerCase()}` : "image/jpeg";
+
+    // Create form data
+    const formData = new FormData();
+    formData.append("file", {
+      uri: imageUri,
+      name: filename,
+      type: type,
+    } as any);
+
+    console.log("[API] Uploading image:", { url, filename, type });
+
+    const response = await this.fetchWithRetry(url, {
+      method: "POST",
+      body: formData,
+      // Don't set Content-Type header - fetch will set it with boundary
+    });
+
+    console.log("[API] Upload response status:", response.status);
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ detail: "Failed to upload image" }));
+      console.error("[API] Upload error:", error);
+      throw new Error(error.detail || "Failed to upload image");
+    }
+
+    const responseData = await response.json();
+    console.log("[API] Upload success:", responseData);
     return responseData;
   }
 
@@ -916,7 +977,11 @@ class ApiClient {
    * Get user statistics (farmers reached, conversations resolved, messages sent)
    */
   async getUserStats(): Promise<{
-    farmers_reached: { this_week: number; this_month: number; all_time: number };
+    farmers_reached: {
+      this_week: number;
+      this_month: number;
+      all_time: number;
+    };
     conversations_resolved: {
       this_week: number;
       this_month: number;

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from "expo-secure-store";
+import * as FileSystem from "expo-file-system/legacy";
 import { tokenEmitter, TOKEN_CHANGED } from "@/utils/tokenEvents";
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_AGRICONNECT_SERVER_URL || "";
@@ -443,39 +444,90 @@ class ApiClient {
     const url = `${this.baseUrl}/messages/upload-image`;
 
     // Get filename and type from URI
-    const filename = imageUri.split("/").pop() || "image.jpg";
-    const match = /\.(\w+)$/.exec(filename);
-    const type = match ? `image/${match[1].toLowerCase()}` : "image/jpeg";
+    const originalFilename = imageUri.split("/").pop() || "image.jpg";
+    const match = /\.(\w+)$/.exec(originalFilename);
+    const ext = match ? match[1].toLowerCase() : "jpg";
+    const type = `image/${ext === "jpg" ? "jpeg" : ext}`;
 
-    // Create form data
+    console.log("[API] Preparing image upload:", {
+      url,
+      imageUri,
+      originalFilename,
+      type,
+    });
+
+    let uploadUri = imageUri;
+    let tempFilePath: string | null = null;
+
+    try {
+      // Verify the file exists
+      const fileInfo = await FileSystem.getInfoAsync(imageUri);
+      console.log("[API] File info:", fileInfo);
+
+      if (!fileInfo.exists) {
+        throw new Error("Image file does not exist at the specified URI");
+      }
+
+      // Copy file to cache directory with a unique name for reliable access
+      // This helps on Android where the original URI might not be accessible
+      const uniqueFilename = `upload_${Date.now()}.${ext}`;
+      tempFilePath = `${FileSystem.cacheDirectory}${uniqueFilename}`;
+
+      console.log("[API] Copying file to cache:", tempFilePath);
+      await FileSystem.copyAsync({
+        from: imageUri,
+        to: tempFilePath,
+      });
+
+      uploadUri = tempFilePath;
+      console.log("[API] Using cached file for upload:", uploadUri);
+    } catch (fileError) {
+      console.error("[API] File preparation error:", fileError);
+      // Try to continue with original URI if copy fails
+      console.log("[API] Falling back to original URI");
+    }
+
+    // Create form data with the prepared URI
     const formData = new FormData();
     formData.append("file", {
-      uri: imageUri,
-      name: filename,
+      uri: uploadUri,
+      name: `image.${ext}`,
       type: type,
     } as any);
 
-    console.log("[API] Uploading image:", { url, filename, type });
+    console.log("[API] Uploading image with URI:", uploadUri);
 
-    const response = await this.fetchWithRetry(url, {
-      method: "POST",
-      body: formData,
-      // Don't set Content-Type header - fetch will set it with boundary
-    });
+    try {
+      const response = await this.fetchWithRetry(url, {
+        method: "POST",
+        body: formData,
+        // Don't set Content-Type header - fetch will set it with boundary
+      });
 
-    console.log("[API] Upload response status:", response.status);
+      console.log("[API] Upload response status:", response.status);
 
-    if (!response.ok) {
-      const error = await response
-        .json()
-        .catch(() => ({ detail: "Failed to upload image" }));
-      console.error("[API] Upload error:", error);
-      throw new Error(error.detail || "Failed to upload image");
+      if (!response.ok) {
+        const error = await response
+          .json()
+          .catch(() => ({ detail: "Failed to upload image" }));
+        console.error("[API] Upload error:", error);
+        throw new Error(error.detail || "Failed to upload image");
+      }
+
+      const responseData = await response.json();
+      console.log("[API] Upload success:", responseData);
+      return responseData;
+    } finally {
+      // Clean up temp file
+      if (tempFilePath) {
+        try {
+          await FileSystem.deleteAsync(tempFilePath, { idempotent: true });
+          console.log("[API] Cleaned up temp file:", tempFilePath);
+        } catch (cleanupError) {
+          console.warn("[API] Failed to clean up temp file:", cleanupError);
+        }
+      }
     }
-
-    const responseData = await response.json();
-    console.log("[API] Upload success:", responseData);
-    return responseData;
   }
 
   async registerDevice(deviceData: {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4509,6 +4509,18 @@ expo-haptics@~15.0.7:
   resolved "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.7.tgz"
   integrity sha512-7flWsYPrwjJxZ8x82RiJtzsnk1Xp9ahnbd9PhCy3NnsemyMApoWIEUr4waPqFr80DtiLZfhD9VMLL1CKa8AImQ==
 
+expo-image-loader@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-6.0.0.tgz#15230442cbb90e101c080a4c81e37d974e43e072"
+  integrity sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==
+
+expo-image-picker@~17.0.11:
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-17.0.11.tgz#8f1537df946f7c19747ba9d0043ef7e3e8cb67dc"
+  integrity sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==
+  dependencies:
+    expo-image-loader "~6.0.0"
+
 expo-image@~3.0.8:
   version "3.0.8"
   resolved "https://registry.npmjs.org/expo-image/-/expo-image-3.0.8.tgz"

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -1,11 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
 from sqlalchemy.orm import Session
 from datetime import datetime, timezone
 from pydantic import BaseModel
 from typing import Optional, List
 
 from database import get_db
-from models.message import Message, MessageFrom, MessageStatus
+from models.message import Message, MessageFrom, MessageStatus, MediaType
 from models.ticket import Ticket
 from models.user import User, UserType
 from models.administrative import UserAdministrative
@@ -61,6 +64,9 @@ class MessageCreate(BaseModel):
     body: str
     # MessageFrom.USER, MessageFrom.CUSTOMER, or MessageFrom.LLM
     from_source: int
+    # Optional media fields for image messages
+    media_url: Optional[str] = None  # Relative path like /media/abc.jpg
+    media_type: Optional[str] = "TEXT"  # TEXT, IMAGE, etc.
 
 
 class MessageResponse(BaseModel):
@@ -73,6 +79,8 @@ class MessageResponse(BaseModel):
     status: int
     message_sid: str
     created_at: datetime
+    media_url: Optional[str] = None
+    media_type: str = "TEXT"
 
 
 def _check_message_access(message: Message, user: User, db: Session) -> None:
@@ -105,6 +113,77 @@ def _check_message_access(message: Message, user: User, db: Session) -> None:
                 " outside your administrative area"
             ),
         )
+
+
+# Allowed image types for upload
+ALLOWED_IMAGE_TYPES = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+# Max file size: 16MB (Twilio limit for WhatsApp media)
+MAX_IMAGE_SIZE = 16 * 1024 * 1024
+
+
+@router.post("/upload-image")
+async def upload_message_image(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Upload an image for sending via WhatsApp.
+
+    Validates image type and size, saves to /media directory,
+    and returns the media URL for use in message creation.
+
+    Supported formats: jpeg, png, webp, gif
+    Max file size: 16MB (Twilio WhatsApp limit)
+
+    Returns:
+        {"media_url": "/media/{filename}", "media_type": "IMAGE"}
+    """
+    # Validate content type
+    content_type = file.content_type
+    if content_type not in ALLOWED_IMAGE_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid image type: {content_type}. "
+                f"Allowed types: {list(ALLOWED_IMAGE_TYPES.keys())}"
+            ),
+        )
+
+    # Read file content
+    content = await file.read()
+
+    # Validate file size
+    if len(content) > MAX_IMAGE_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Image too large: {len(content) / (1024 * 1024):.2f}MB. "
+                f"Max size: 16MB"
+            ),
+        )
+
+    # Generate unique filename
+    extension = ALLOWED_IMAGE_TYPES[content_type]
+    filename = f"{uuid.uuid4().hex}.{extension}"
+
+    # Ensure media directory exists
+    media_dir = "media"
+    os.makedirs(media_dir, exist_ok=True)
+
+    # Save file
+    file_path = os.path.join(media_dir, filename)
+    with open(file_path, "wb") as f:
+        f.write(content)
+
+    return {
+        "media_url": f"/media/{filename}",
+        "media_type": "IMAGE",
+    }
 
 
 @router.patch("/{message_id}/status", response_model=MessageResponse)
@@ -175,6 +254,13 @@ async def update_message_status(
                 resolved_by=current_user.full_name,
             )
 
+    # Get media_type value as string
+    msg_media_type = (
+        message.media_type.value
+        if message.media_type
+        else "TEXT"
+    )
+
     return MessageResponse(
         id=message.id,
         ticket_id=ticket.id if ticket else None,
@@ -185,6 +271,8 @@ async def update_message_status(
         status=message.status,
         message_sid=message.message_sid,
         created_at=message.created_at,
+        media_url=message.media_url,
+        media_type=msg_media_type,
     )
 
 
@@ -247,6 +335,15 @@ async def create_message(
 
     # Create new message
     timestamp_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    # Determine media_type enum value
+    media_type_enum = MediaType.TEXT
+    if message_data.media_type and message_data.media_type != "TEXT":
+        try:
+            media_type_enum = MediaType[message_data.media_type]
+        except KeyError:
+            pass  # Default to TEXT if invalid
+
     new_message = Message(
         message_sid=f"USER_{current_user.id}_{timestamp_ms}",
         customer_id=ticket.customer_id,
@@ -254,6 +351,8 @@ async def create_message(
         body=message_data.body,
         from_source=message_data.from_source,
         status=MessageStatus.PENDING,  # New messages start as pending
+        media_url=message_data.media_url,
+        media_type=media_type_enum,
     )
 
     db.add(new_message)
@@ -282,15 +381,30 @@ async def create_message(
                 f"{new_message.body}\n\n— _{current_user.full_name}_"
             )
 
-            response = whatsapp_service.send_message(
-                to_number=customer_phone,
-                message_body=formatted_body,
-            )
+            # Check if this is a media message
+            if message_data.media_url and message_data.media_type == "IMAGE":
+                # Build full public URL for the media
+                web_domain = os.getenv("WEBDOMAIN", "http://localhost:8000")
+                full_media_url = f"{web_domain}{message_data.media_url}"
 
-            print(
-                f"WhatsApp reply sent to {customer_phone}: "
-                f"{response.get('sid')}"
-            )
+                response = whatsapp_service.send_message_with_media(
+                    to_number=customer_phone,
+                    message_body=formatted_body,
+                    media_url=full_media_url,
+                )
+                print(
+                    f"WhatsApp image sent to {customer_phone}: "
+                    f"{response.get('sid')} (media: {full_media_url})"
+                )
+            else:
+                response = whatsapp_service.send_message(
+                    to_number=customer_phone,
+                    message_body=formatted_body,
+                )
+                print(
+                    f"WhatsApp reply sent to {customer_phone}: "
+                    f"{response.get('sid')}"
+                )
 
             # Optional: Update message_sid with Twilio SID for tracking
             # This helps correlate backend messages with Twilio messages
@@ -335,6 +449,13 @@ async def create_message(
         customer_id=ticket.customer_id,
     )
 
+    # Get media_type value as string
+    media_type_value = (
+        new_message.media_type.value
+        if new_message.media_type
+        else "TEXT"
+    )
+
     return MessageResponse(
         id=new_message.id,
         ticket_id=ticket.id,
@@ -345,4 +466,6 @@ async def create_message(
         status=new_message.status,
         message_sid=new_message.message_sid,
         created_at=new_message.created_at,
+        media_url=new_message.media_url,
+        media_type=media_type_value,
     )

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -154,17 +154,15 @@ async def upload_message_image(
             ),
         )
 
-    # Read file content
-    content = await file.read()
+    # Read file content with size limit to prevent memory exhaustion
+    # Read MAX_IMAGE_SIZE + 1 bytes to detect oversized files early
+    content = await file.read(MAX_IMAGE_SIZE + 1)
 
     # Validate file size
     if len(content) > MAX_IMAGE_SIZE:
         raise HTTPException(
             status_code=400,
-            detail=(
-                f"Image too large: {len(content) / (1024 * 1024):.2f}MB. "
-                f"Max size: 16MB"
-            ),
+            detail="Image too large. Max size: 16MB",
         )
 
     # Generate unique filename
@@ -342,7 +340,14 @@ async def create_message(
         try:
             media_type_enum = MediaType[message_data.media_type]
         except KeyError:
-            pass  # Default to TEXT if invalid
+            valid_types = [t.name for t in MediaType]
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid media_type: {message_data.media_type}. "
+                    f"Allowed types: {valid_types}"
+                ),
+            )
 
     new_message = Message(
         message_sid=f"USER_{current_user.id}_{timestamp_ms}",
@@ -385,7 +390,12 @@ async def create_message(
             if message_data.media_url and message_data.media_type == "IMAGE":
                 # Build full public URL for the media
                 web_domain = os.getenv("WEBDOMAIN", "http://localhost:8000")
-                full_media_url = f"{web_domain}{message_data.media_url}"
+                # Ensure web_domain has a scheme
+                if not web_domain.startswith(("http://", "https://")):
+                    web_domain = f"https://{web_domain}"
+                # Ensure no double slashes when joining
+                media_path = message_data.media_url.lstrip("/")
+                full_media_url = f"{web_domain.rstrip('/')}/{media_path}"
 
                 response = whatsapp_service.send_message_with_media(
                     to_number=customer_phone,

--- a/backend/services/whatsapp_service.py
+++ b/backend/services/whatsapp_service.py
@@ -282,6 +282,48 @@ class WhatsAppService:
         except Exception as e:
             raise Exception(f"Failed to send WhatsApp message: {e}")
 
+    def send_message_with_media(
+        self, to_number: str, message_body: str, media_url: str
+    ) -> Dict[str, Any]:
+        """
+        Send WhatsApp message with media via Twilio.
+
+        Args:
+            to_number: Customer phone number (E.164 format)
+            message_body: Text caption for the image
+            media_url: Publicly accessible HTTPS URL to the image
+
+        Returns:
+            Dict with sid, status, to, body keys
+
+        Note:
+            - Media URL must be publicly accessible
+            - Twilio supports images up to 16MB
+            - Supported formats: jpeg, png, webp, gif
+        """
+        if self.testing_mode:
+            logger.info(
+                f"[TESTING MODE] Mocking WhatsApp message with media "
+                f"to {to_number}: {message_body[:50]}... "
+                f"media_url: {media_url}"
+            )
+
+        try:
+            message = self.client.messages.create(
+                from_=self.whatsapp_number,
+                body=message_body,
+                to=f"whatsapp:{to_number}",
+                media_url=[media_url],
+            )
+            return {
+                "sid": message.sid,
+                "status": message.status,
+                "to": message.to,
+                "body": message.body,
+            }
+        except Exception as e:
+            raise Exception(f"Failed to send WhatsApp message with media: {e}")
+
     def send_welcome_message(
         self, to_number: str, language: str = "en"
     ) -> Dict[str, Any]:

--- a/backend/tests/test_message_endpoint.py
+++ b/backend/tests/test_message_endpoint.py
@@ -736,3 +736,196 @@ class TestMessageEndpoints:
         # The sender_name should be customer's full_name or phone_number
         assert self.customer.full_name is not None or \
             self.customer.phone_number is not None
+
+    # ============ Image Upload Tests ============
+
+    def test_upload_image_valid_jpeg(self):
+        """Test uploading a valid JPEG image"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        # Create a simple valid JPEG file (minimal JPEG header)
+        jpeg_content = (
+            b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01'
+            b'\x00\x00\x01\x00\x01\x00\x00\xff\xdb\x00C'
+            + b'\x00' * 64
+            + b'\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00'
+            + b'\xff\xd9'
+        )
+
+        response = self.client.post(
+            "/api/messages/upload-image",
+            files={"file": ("test.jpg", jpeg_content, "image/jpeg")},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "media_url" in data
+        assert data["media_url"].startswith("/media/")
+        assert data["media_url"].endswith(".jpg")
+        assert data["media_type"] == "IMAGE"
+
+    def test_upload_image_valid_png(self):
+        """Test uploading a valid PNG image"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        # Minimal valid PNG
+        png_content = (
+            b'\x89PNG\r\n\x1a\n'
+            b'\x00\x00\x00\rIHDR'
+            b'\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02'
+            b'\x00\x00\x00\x90wS\xde'
+            b'\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05'
+            b'\x18\xd8N'
+            b'\x00\x00\x00\x00IEND\xaeB`\x82'
+        )
+
+        response = self.client.post(
+            "/api/messages/upload-image",
+            files={"file": ("test.png", png_content, "image/png")},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["media_url"].endswith(".png")
+
+    def test_upload_image_invalid_type(self):
+        """Test uploading an invalid file type"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        response = self.client.post(
+            "/api/messages/upload-image",
+            files={"file": ("test.txt", b"not an image", "text/plain")},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "Invalid image type" in response.json()["detail"]
+
+    def test_upload_image_too_large(self):
+        """Test uploading an image that exceeds size limit"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        # Create content larger than 16MB
+        large_content = b'\xff\xd8\xff\xe0' + (b'\x00' * (17 * 1024 * 1024))
+
+        response = self.client.post(
+            "/api/messages/upload-image",
+            files={"file": ("large.jpg", large_content, "image/jpeg")},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "too large" in response.json()["detail"]
+
+    def test_upload_image_without_auth(self):
+        """Test uploading image without authentication"""
+        response = self.client.post(
+            "/api/messages/upload-image",
+            files={"file": ("test.jpg", b"test", "image/jpeg")},
+        )
+
+        assert response.status_code in [401, 403]
+
+    # ============ Media Message Tests ============
+
+    @patch("routers.messages.WhatsAppService")
+    def test_create_message_with_media_sends_whatsapp_media(
+        self, mock_whatsapp_service
+    ):
+        """Test that message with media uses send_message_with_media"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        mock_service_instance = MagicMock()
+        mock_service_instance.send_message_with_media.return_value = {
+            "sid": "MM1234567890",
+            "status": "queued",
+        }
+        mock_whatsapp_service.return_value = mock_service_instance
+
+        payload = {
+            "ticket_id": self.ticket.id,
+            "body": "[Image]",
+            "from_source": MessageFrom.USER,
+            "media_url": "/media/test123.jpg",
+            "media_type": "IMAGE",
+        }
+
+        with patch.dict("os.environ", {"WEBDOMAIN": "https://example.com"}):
+            response = self.client.post(
+                "/api/messages",
+                json=payload,
+                headers=headers,
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["media_url"] == "/media/test123.jpg"
+        assert data["media_type"] == "IMAGE"
+
+        # Verify send_message_with_media was called
+        mock_service_instance.send_message_with_media.assert_called_once()
+        call_args = mock_service_instance.send_message_with_media.call_args
+        call_kwargs = call_args[1]
+        expected_url = "https://example.com/media/test123.jpg"
+        assert call_kwargs["media_url"] == expected_url
+
+    @patch("routers.messages.WhatsAppService")
+    def test_create_message_with_media_url_construction(
+        self, mock_whatsapp_service
+    ):
+        """Test that media URL is properly constructed with scheme"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        mock_service_instance = MagicMock()
+        mock_service_instance.send_message_with_media.return_value = {
+            "sid": "MM9876543210",
+        }
+        mock_whatsapp_service.return_value = mock_service_instance
+
+        payload = {
+            "ticket_id": self.ticket.id,
+            "body": "[Image]",
+            "from_source": MessageFrom.USER,
+            "media_url": "/media/image.png",
+            "media_type": "IMAGE",
+        }
+
+        # Test with WEBDOMAIN without scheme
+        with patch.dict("os.environ", {"WEBDOMAIN": "example.com"}):
+            response = self.client.post(
+                "/api/messages",
+                json=payload,
+                headers=headers,
+            )
+
+        assert response.status_code == 201
+
+        # Verify URL has https:// scheme added
+        call_args = mock_service_instance.send_message_with_media.call_args
+        call_kwargs = call_args[1]
+        assert call_kwargs["media_url"].startswith("https://")
+        # No double slashes
+        assert "///" not in call_kwargs["media_url"]
+
+    def test_create_message_invalid_media_type(self):
+        """Test that invalid media_type returns 400 error"""
+        headers = self._get_auth_headers(self.eo_user)
+
+        payload = {
+            "ticket_id": self.ticket.id,
+            "body": "Test message",
+            "from_source": MessageFrom.USER,
+            "media_url": "/media/test.jpg",
+            "media_type": "INVALID_TYPE",
+        }
+
+        response = self.client.post(
+            "/api/messages",
+            json=payload,
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "Invalid media_type" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Enable Extension Officers to send images to customers via WhatsApp from the mobile app
- Images can be selected from camera or gallery, previewed before sending, and are delivered via Twilio's media messaging API

## Changes

### Backend
- Add `send_message_with_media()` to WhatsApp service for Twilio media messages
- Add `/messages/upload-image` endpoint for image uploads (validates type & max 16MB)
- Update `MessageCreate` schema to accept `media_url` and `media_type`
- Modify `create_message()` to send images via WhatsApp when media is present

### Mobile App
- Install `expo-image-picker` for camera/gallery access
- Add `uploadImage()` and update `sendMessage()` in API client
- Create `ImagePickerButton` component with camera/gallery selection dialog
- Create `ImagePreview` component with thumbnail and remove button
- Update `ChatInput` to handle image selection, upload, and send
- Update `MessageBubble` to display user-sent images

## Test Plan
- [ ] Open chat with a customer in the mobile app
- [ ] Tap image button and select "Camera" → verify camera opens
- [ ] Tap image button and select "Gallery" → verify gallery opens
- [ ] Select an image → verify preview thumbnail appears above input
- [ ] Tap X on preview → verify image is removed
- [ ] Select image and tap send → verify image uploads and sends
- [ ] Verify customer receives image on WhatsApp
- [ ] Verify sent image appears in chat UI for EO
- [ ] Test sending image with caption text
- [ ] Test offline mode → verify image button is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)