### PR TITLE
[#178] Reduce weather broadcast frequency to every 3 days

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -35,10 +35,10 @@ celery_app.conf.beat_schedule = {
         "task": "tasks.broadcast_tasks.retry_failed_broadcasts",
         "schedule": crontab(minute="*/5"),
     },
-    # Weather broadcasts daily at 6 AM UTC
+    # Weather broadcasts every 3 days at 6 AM UTC
     "send-weather-broadcasts": {
         "task": "tasks.weather_tasks.send_weather_broadcasts",
-        "schedule": crontab(hour=6, minute=0),
+        "schedule": crontab(hour=6, minute=0, day_of_month="*/3"),
     },
     # Retry failed weather broadcasts every 5 minutes
     "retry-failed-weather-broadcasts": {

--- a/backend/tasks/weather_tasks.py
+++ b/backend/tasks/weather_tasks.py
@@ -403,6 +403,7 @@ def send_weather_message(
     Send actual weather message after user confirmation.
 
     Called when user clicks "Yes" on the template message.
+    Always fetches fresh weather data to ensure user gets current forecast.
 
     Args:
         recipient_id: ID of the WeatherBroadcastRecipient
@@ -438,16 +439,40 @@ def send_weather_message(
             logger.error("Customer or broadcast not found")
             return {"error": "Customer or broadcast not found"}
 
-        # Get message in customer's language
-        customer_lang = customer.language.value if customer.language else "en"
-        message_content = (
-            broadcast.generated_message_sw
-            if customer_lang == "sw"
-            else broadcast.generated_message_en
+        # Fetch FRESH weather data (not cached from broadcast)
+        weather_service = get_weather_broadcast_service()
+        area = broadcast.administrative
+
+        weather_data = weather_service.get_weather_data(
+            location=broadcast.location_name,
+            lat=area.lat if area else None,
+            lon=area.long if area else None,
         )
 
+        if not weather_data:
+            location = broadcast.location_name
+            logger.error(f"Failed to get fresh weather data for {location}")
+            return {"error": "Failed to get weather data"}
+
+        # Generate fresh message in customer's language
+        customer_lang = customer.language.value if customer.language else "en"
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            message_content = loop.run_until_complete(
+                weather_service.generate_message(
+                    location=broadcast.location_name,
+                    language=customer_lang,
+                    weather_data=weather_data,
+                    farmer_crop=customer.crop_type or broadcast.crop_type,
+                )
+            )
+        finally:
+            loop.close()
+
         if not message_content:
-            logger.error("No generated message content available")
+            logger.error("Failed to generate fresh weather message")
             return {"error": "No message content"}
 
         # Send message

--- a/backend/tests/test_weather_tasks.py
+++ b/backend/tests/test_weather_tasks.py
@@ -362,12 +362,23 @@ class TestSendWeatherMessage:
         assert "error" in result
         assert "not found" in result["error"].lower()
 
+    @patch("tasks.weather_tasks.get_weather_broadcast_service")
     @patch("tasks.weather_tasks.SessionLocal")
     def test_send_weather_message_success(
-        self, mock_sl, db_session, test_weather_setup
+        self, mock_sl, mock_weather_svc, db_session, test_weather_setup
     ):
-        """Test successful weather message sending"""
+        """Test successful weather message sending with fresh weather"""
         mock_sl.return_value = db_session
+
+        # Mock weather service to return fresh data
+        mock_service = MagicMock()
+        mock_service.get_weather_data.return_value = {"temp": 25}
+
+        # Mock async generate_message using a coroutine
+        async def mock_generate(*args, **kwargs):
+            return "Fresh weather forecast for today..."
+        mock_service.generate_message = mock_generate
+        mock_weather_svc.return_value = mock_service
 
         # Get a recipient and store IDs
         broadcast_id = test_weather_setup["broadcast"].id
@@ -391,6 +402,9 @@ class TestSendWeatherMessage:
         assert "status" in result
         assert result["status"] == "sent"
 
+        # Verify weather service was called to fetch fresh data
+        assert mock_service.get_weather_data.called
+
         # Verify recipient updated
         db_session.expire_all()
         updated_recipient = db_session.query(WeatherBroadcastRecipient).get(
@@ -400,15 +414,26 @@ class TestSendWeatherMessage:
         assert updated_recipient.confirmed_at is not None
         assert updated_recipient.message_id is not None
 
+    @patch("tasks.weather_tasks.get_weather_broadcast_service")
     @patch("tasks.weather_tasks.SessionLocal")
     def test_send_weather_message_no_content(
-        self, mock_sl, db_session, test_administrative,
+        self, mock_sl, mock_weather_svc, db_session, test_administrative,
         test_customer_subscribed
     ):
-        """Test task handles missing message content"""
+        """Test task handles missing message content from weather service"""
         mock_sl.return_value = db_session
 
-        # Create broadcast without generated messages
+        # Mock weather service to return data but None for message
+        mock_service = MagicMock()
+        mock_service.get_weather_data.return_value = {"temp": 25}
+
+        # Mock async generate_message returning None
+        async def mock_generate(*args, **kwargs):
+            return None  # No message generated
+        mock_service.generate_message = mock_generate
+        mock_weather_svc.return_value = mock_service
+
+        # Create broadcast
         broadcast = WeatherBroadcast(
             administrative_id=test_administrative.id,
             location_name=test_administrative.name,
@@ -579,18 +604,29 @@ class TestWeatherTasksIntegration:
                 if original_testing:
                     os.environ["TESTING"] = original_testing
 
+    @patch("tasks.weather_tasks.get_weather_broadcast_service")
     @patch("tasks.weather_tasks.SessionLocal")
     @patch("tasks.weather_tasks.WhatsAppService")
     def test_send_weather_message_non_test_mode(
-        self, mock_ws_class, mock_sl, db_session, test_weather_setup
+        self, mock_ws_class, mock_sl, mock_weather_svc,
+        db_session, test_weather_setup
     ):
-        """Test actual weather message send"""
+        """Test actual weather message send with fresh weather"""
         mock_sl.return_value = db_session
 
         # Mock WhatsApp service
-        mock_service = MagicMock()
-        mock_service.send_message.return_value = {"sid": "SM_ACTUAL_456"}
-        mock_ws_class.return_value = mock_service
+        mock_wa_service = MagicMock()
+        mock_wa_service.send_message.return_value = {"sid": "SM_ACTUAL_456"}
+        mock_ws_class.return_value = mock_wa_service
+
+        # Mock weather service to return fresh data
+        mock_weather = MagicMock()
+        mock_weather.get_weather_data.return_value = {"temp": 25}
+
+        async def mock_generate(*args, **kwargs):
+            return "Fresh weather forecast..."
+        mock_weather.generate_message = mock_generate
+        mock_weather_svc.return_value = mock_weather
 
         # Get recipient
         recipient = db_session.query(WeatherBroadcastRecipient).filter(
@@ -614,7 +650,8 @@ class TestWeatherTasksIntegration:
             )
 
             assert "status" in result
-            assert mock_service.send_message.called
+            assert mock_wa_service.send_message.called
+            assert mock_weather.get_weather_data.called
         finally:
             # Restore test mode
             if original_testing:

--- a/backend/utils/i18n.py
+++ b/backend/utils/i18n.py
@@ -434,12 +434,12 @@ trans: Dict[str, Any] = {
     "weather_subscription": {
         "question": {
             "en": (
-                "\n\nWould you like to receive daily morning weather updates "
+                "\n\nWould you like to receive weather updates "
                 "for your area ({area_name})?"
             ),
             "sw": (
-                "\n\nJe, ungependa kupokea taarifa za hali ya anga kila "
-                "siku asubuhi kwa eneo lako ({area_name})?"
+                "\n\nJe, ungependa kupokea taarifa za hali ya anga "
+                "kwa eneo lako ({area_name})?"
             ),
         },
         "button_yes": {
@@ -452,15 +452,16 @@ trans: Dict[str, Any] = {
         },
         "subscribed": {
             "en": (
-                "Great! You will receive daily updates for {area_name}.\n\n"
-                "Please message *weather* to get weather information "
-                "on-demand."
+                "Great! You will receive automated weather broadcasts "
+                "every 3 days for {area_name}.\n\n"
+                "Don't want to wait? Just message *weather* anytime "
+                "to get your forecast instantly!"
             ),
             "sw": (
-                "Vizuri! Utapokea taarifa za hali ya hewa kila siku "
-                "kwa {area_name}.\n\n"
-                "Tafadhali tuma ujumbe *weather* kupata taarifa za hali ya "
-                "hewa wakati wowote."
+                "Vizuri! Utapokea taarifa za hali ya hewa kiotomatiki "
+                "kila siku 3 kwa {area_name}.\n\n"
+                "Hutaki kusubiri? Tuma ujumbe *weather* wakati wowote "
+                "kupata utabiri wako mara moja!"
             ),
         },
         "declined": {


### PR DESCRIPTION
## Summary
- Reduce weather broadcast frequency from daily to every 3 days to optimize costs
- Update confirmation message to emphasize on-demand weather access via "weather" command
- Fetch fresh weather data when users confirm template (instead of potentially stale cached data)

## Test plan
- [ ] Verify Celery beat schedule runs every 3 days
- [ ] Verify confirmation message displays correctly in EN and SW
- [ ] Verify clicking "Yes" on template sends fresh weather (not cached)
- [ ] Verify messaging "weather" still returns immediate response

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215708431380202