### PR TITLE
[#183] Add citation tooltips and knowledge base display to playground

### DIFF
--- a/backend/routers/admin_playground.py
+++ b/backend/routers/admin_playground.py
@@ -15,6 +15,7 @@ from models.playground_message import (
     PlaygroundMessageRole,
     PlaygroundMessageStatus,
 )
+from models.knowledge_base import KnowledgeBase
 from services.external_ai_service import ExternalAIService
 from services.service_token_service import ServiceTokenService
 from schemas.callback import MessageType
@@ -34,6 +35,7 @@ class ActiveServiceResponse(BaseModel):
     chat_url: str
     is_active: bool
     has_valid_token: bool
+    active_knowledge_base_id: Optional[int] = None
 
 
 class DefaultPromptResponse(BaseModel):
@@ -116,11 +118,22 @@ def get_active_service(
             detail="No active service configured",
         )
 
+    # Get active knowledge base for this service
+    active_kb = (
+        db.query(KnowledgeBase)
+        .filter(
+            KnowledgeBase.service_id == token.id,
+            KnowledgeBase.is_active == True,  # noqa: E712
+        )
+        .first()
+    )
+
     return ActiveServiceResponse(
         service_name=token.service_name,
         chat_url=token.chat_url or "",
         is_active=token.active == 1,
         has_valid_token=bool(token.access_token),
+        active_knowledge_base_id=active_kb.id if active_kb else None,
     )
 
 

--- a/backend/routers/callbacks.py
+++ b/backend/routers/callbacks.py
@@ -98,11 +98,24 @@ async def handle_playground_callback(payload: AIWebhookCallback, db: Session):
 
         session_id = payload.callback_params.session_id
         if session_id:
+            # Convert citations to dicts for JSON serialization
+            citations = []
+            if payload.output.citations:
+                citations = [
+                    {
+                        "document": c.document,
+                        "chunk": c.chunk,
+                        "page": c.page,
+                    }
+                    for c in payload.output.citations
+                ]
+
             await emit_playground_response(
                 session_id=session_id,
                 message_id=pg_message.id,
                 content=pg_message.content,
                 response_time_ms=response_time_ms,
+                citations=citations,
             )
 
         return {"status": "received", "job_id": payload.job_id}

--- a/backend/schemas/callback.py
+++ b/backend/schemas/callback.py
@@ -26,8 +26,12 @@ class MessageType(int, Enum):
 
 
 class Citation(BaseModel):
-    document: str = Field(..., description="Title of the cited source")
-    chunk: str = Field(..., description="Content of the cited source")
+    document: Optional[str] = Field(
+        None, description="Title/filename of the cited source"
+    )
+    chunk: Optional[str] = Field(
+        None, description="Content of the cited source"
+    )
     page: Optional[str] = Field(
         None, description="Page number or identifier of the source"
     )

--- a/backend/services/socketio_service.py
+++ b/backend/services/socketio_service.py
@@ -348,7 +348,11 @@ async def emit_message_received(
 
 
 async def emit_playground_response(
-    session_id: str, message_id: int, content: str, response_time_ms: int
+    session_id: str,
+    message_id: int,
+    content: str,
+    response_time_ms: int,
+    citations: list = None,
 ):
     """Emit response"""
     event_data = {
@@ -358,6 +362,7 @@ async def emit_playground_response(
         "response_time_ms": response_time_ms,
         "role": "assistant",
         "status": "completed",
+        "citations": citations or [],
     }
 
     room_name = f"playground:{session_id}"

--- a/frontend/src/app/playground/page.js
+++ b/frontend/src/app/playground/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import api from "../../lib/api";
+import knowledgeBaseApi from "../../lib/knowledgeBaseApi";
 import HeaderNav from "../../components/HeaderNav";
 import {
   PaperAirplaneIcon,
@@ -13,6 +14,7 @@ import {
   XCircleIcon,
   ClockIcon,
   TrashIcon,
+  DocumentTextIcon,
 } from "@heroicons/react/24/outline";
 import { io } from "socket.io-client";
 
@@ -31,6 +33,9 @@ export default function PlaygroundPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [socket, setSocket] = useState(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [documents, setDocuments] = useState([]);
+  const [knowledgeBase, setKnowledgeBase] = useState(null);
+  const [loadingDocs, setLoadingDocs] = useState(false);
   const messagesEndRef = useRef(null);
 
   // Redirect non-admins
@@ -67,6 +72,29 @@ export default function PlaygroundPage() {
     }
   };
 
+  // Fetch documents when active knowledge base is available
+  useEffect(() => {
+    if (activeService?.active_knowledge_base_id) {
+      fetchDocuments(activeService.active_knowledge_base_id);
+    }
+  }, [activeService?.active_knowledge_base_id]);
+
+  const fetchDocuments = async (kbId) => {
+    try {
+      setLoadingDocs(true);
+      const [kbDetails, docsResponse] = await Promise.all([
+        knowledgeBaseApi.getById(kbId),
+        knowledgeBaseApi.getDocumentList(kbId, 1, 100),
+      ]);
+      setKnowledgeBase(kbDetails);
+      setDocuments(docsResponse.data || []);
+    } catch (err) {
+      console.error("Error fetching documents:", err);
+    } finally {
+      setLoadingDocs(false);
+    }
+  };
+
   // WebSocket setup
   useEffect(() => {
     if (!user) return;
@@ -94,6 +122,13 @@ export default function PlaygroundPage() {
     });
 
     newSocket.on("playground_response", (data) => {
+      // Debug: Log incoming WebSocket data
+      console.log("[Playground WS] Received response:", {
+        message_id: data.message_id,
+        citations_count: data.citations?.length || 0,
+        citations: data.citations,
+      });
+
       // Use functional update to avoid stale state
       setMessages((prevMessages) => {
         const updated = prevMessages.map((msg) =>
@@ -103,6 +138,7 @@ export default function PlaygroundPage() {
                 content: data.content,
                 status: "completed",
                 response_time_ms: data.response_time_ms,
+                citations: data.citations || [],
               }
             : msg
         );
@@ -147,15 +183,15 @@ export default function PlaygroundPage() {
         response.data.assistant_message,
       ];
 
-      console.log("=== SENDING MESSAGE ===");
-      console.log("Current messages count:", messages.length);
-      console.log("New messages count:", newMessages.length);
-      console.log("User message ID:", response.data.user_message.id);
-      console.log("Assistant message ID:", response.data.assistant_message.id);
-      console.log("New messages:", newMessages);
+      // Join playground room IMMEDIATELY before state updates
+      // This prevents race condition where callback arrives before useEffect runs
+      const newSessionId = response.data.session_id;
+      if (socket && isConnected && newSessionId && newSessionId !== currentSessionId) {
+        socket.emit("join_playground", { session_id: newSessionId });
+      }
 
       setMessages(newMessages);
-      setCurrentSessionId(response.data.session_id);
+      setCurrentSessionId(newSessionId);
       setInputMessage("");
     } catch (err) {
       console.error("Error sending message:", err);
@@ -189,6 +225,68 @@ export default function PlaygroundPage() {
 
   const handleClearPrompt = () => {
     setCustomPrompt("");
+  };
+
+  // Format citations like [citation:3] or [citation:1 2 3] into hoverable superscripts
+  const formatCitations = (content, citations = []) => {
+    if (!content) return content;
+
+    // Debug: Log what's being passed to formatCitations
+    if (content.includes("[citation:")) {
+      console.log("[formatCitations] Content has citations, received:", {
+        citationsLength: citations?.length || 0,
+        citations: citations,
+      });
+    }
+
+    // Match [citation:X] or [citation:X Y Z]
+    const parts = content.split(/(\[citation:[^\]]+\])/g);
+
+    return parts.map((part, index) => {
+      const match = part.match(/\[citation:([^\]]+)\]/);
+      if (match) {
+        const citationNums = match[1].trim().split(/\s+/);
+        return (
+          <span key={index} className="inline-flex gap-0.5">
+            {citationNums.map((num, i) => {
+              // Citation numbers are 1-indexed, array is 0-indexed
+              const citationIndex = parseInt(num) - 1;
+              const citation = citations[citationIndex];
+              const filename = citation?.document || `Source ${num}`;
+              const page = citation?.page;
+              const chunk = citation?.chunk || "";
+              // Use single line tooltip - browsers don't render \n in title
+              const preview = chunk
+                ? chunk.substring(0, 150).replace(/\s+/g, " ").trim()
+                : "";
+
+              // Build tooltip based on what data is available
+              let tooltip;
+              if (citation) {
+                if (preview) {
+                  tooltip = `📄 ${filename}${page ? ` (p.${page})` : ""} — ${preview}${chunk.length > 150 ? "..." : ""}`;
+                } else {
+                  tooltip = `📄 ${filename}${page ? ` (p.${page})` : ""}`;
+                }
+              } else {
+                tooltip = `Citation ${num} (no data available)`;
+              }
+
+              return (
+                <sup
+                  key={i}
+                  className="text-blue-600 font-medium text-xs cursor-help hover:text-blue-800 hover:underline"
+                  title={tooltip}
+                >
+                  [{num}]
+                </sup>
+              );
+            })}
+          </span>
+        );
+      }
+      return part;
+    });
   };
 
   // Don't render if not admin
@@ -232,37 +330,52 @@ export default function PlaygroundPage() {
               </div>
 
               {activeService ? (
-                <div className="space-y-3">
+                <div className="space-y-2 text-sm">
                   <div>
-                    <span className="text-sm text-gray-600">Service:</span>
-                    <p className="font-medium">{activeService.service_name}</p>
+                    <span className="text-gray-600">Service:</span>{" "}
+                    <span className="font-medium">{activeService.service_name}</span>
                   </div>
                   <div>
-                    <span className="text-sm text-gray-600">Status:</span>
-                    <div className="flex items-center mt-1">
-                      {activeService.is_active ? (
-                        <>
-                          <CheckCircleIcon className="h-5 w-5 text-green-600 mr-1" />
-                          <span className="text-green-600 text-sm">Active</span>
-                        </>
-                      ) : (
-                        <>
-                          <XCircleIcon className="h-5 w-5 text-red-600 mr-1" />
-                          <span className="text-red-600 text-sm">Inactive</span>
-                        </>
-                      )}
-                    </div>
+                    <span className="text-gray-600">Status:</span>{" "}
+                    {activeService.is_active ? (
+                      <span className="text-green-600">Active</span>
+                    ) : (
+                      <span className="text-red-600">Inactive</span>
+                    )}
                   </div>
-                  {isConnected && (
-                    <div>
-                      <span className="text-sm text-gray-600">WebSocket:</span>
-                      <div className="flex items-center mt-1">
-                        <div className="h-2 w-2 bg-green-500 rounded-full mr-2"></div>
-                        <span className="text-green-600 text-sm">
-                          Connected
+                  <div>
+                    <span className="text-gray-600">Socket:</span>{" "}
+                    {isConnected ? (
+                      <span className="text-green-600">Connected</span>
+                    ) : (
+                      <span className="text-gray-400">Disconnected</span>
+                    )}
+                  </div>
+                  {activeService?.active_knowledge_base_id && (
+                    <>
+                      <div>
+                        <span className="text-gray-600">Knowledge Base:</span>{" "}
+                        <span className="font-medium">
+                          {loadingDocs ? "Loading..." : knowledgeBase?.title || "-"}
                         </span>
                       </div>
-                    </div>
+                      <div>
+                        <span className="text-gray-600">Documents:</span>
+                        {loadingDocs ? (
+                          <span className="text-gray-400 ml-1">Loading...</span>
+                        ) : documents.length > 0 ? (
+                          <ul className="mt-1 space-y-0.5">
+                            {documents.map((doc) => (
+                              <li key={doc.id} className="text-xs text-gray-500 truncate" title={doc.filename}>
+                                • {doc.filename}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <span className="text-gray-400 ml-1">No documents</span>
+                        )}
+                      </div>
+                    </>
                   )}
                 </div>
               ) : (
@@ -306,6 +419,7 @@ export default function PlaygroundPage() {
                 </button>
               </div>
             </div>
+
           </div>
 
           {/* Center Panel - Chat Interface */}
@@ -370,7 +484,7 @@ export default function PlaygroundPage() {
                             </div>
                           ) : (
                             <div className="whitespace-pre-wrap">
-                              {msg.content}
+                              {formatCitations(msg.content, msg.citations)}
                             </div>
                           )}
                           <div className="flex items-center justify-between mt-2 text-xs opacity-75">

--- a/frontend/src/app/playground/page.js
+++ b/frontend/src/app/playground/page.js
@@ -227,6 +227,70 @@ export default function PlaygroundPage() {
     setCustomPrompt("");
   };
 
+  // Citation tooltip component
+  const CitationTooltip = ({ num, citation }) => {
+    const filename = citation?.document || `Source ${num}`;
+    const page = citation?.page;
+    const chunk = citation?.chunk || "";
+    const preview = chunk
+      ? chunk.substring(0, 200).replace(/\s+/g, " ").trim()
+      : "";
+
+    return (
+      <span className="relative inline-block group">
+        <sup className="text-blue-600 font-medium text-xs cursor-help hover:text-blue-800 hover:underline transition-colors">
+          [{num}]
+        </sup>
+        {/* Tooltip card */}
+        <span
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-72
+                     bg-gray-800 rounded-lg shadow-xl
+                     opacity-0 invisible group-hover:opacity-100 group-hover:visible
+                     transition-all duration-200 z-50 pointer-events-none"
+        >
+          {/* Arrow - matching bg-gray-800 */}
+          <span
+            className="absolute top-full left-1/2 -translate-x-1/2
+                       border-8 border-transparent border-t-gray-800"
+          />
+
+          {/* Header */}
+          <span className="flex items-center gap-2 px-3 py-2 border-b border-gray-700">
+            <DocumentTextIcon className="h-4 w-4 text-blue-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-white truncate flex-1">
+              {filename}
+            </span>
+            {page && (
+              <span className="text-xs bg-blue-600 text-white px-1.5 py-0.5 rounded font-medium flex-shrink-0">
+                p.{page}
+              </span>
+            )}
+          </span>
+
+          {/* Content preview */}
+          {citation ? (
+            preview ? (
+              <span className="block px-3 py-2 text-xs text-gray-300 leading-relaxed">
+                {preview}
+                {chunk.length > 200 && (
+                  <span className="text-gray-500">...</span>
+                )}
+              </span>
+            ) : (
+              <span className="block px-3 py-2 text-xs text-gray-500 italic">
+                No preview available
+              </span>
+            )
+          ) : (
+            <span className="block px-3 py-2 text-xs text-amber-400">
+              Citation data not available
+            </span>
+          )}
+        </span>
+      </span>
+    );
+  };
+
   // Format citations like [citation:3] or [citation:1 2 3] into hoverable superscripts
   const formatCitations = (content, citations = []) => {
     if (!content) return content;
@@ -249,37 +313,10 @@ export default function PlaygroundPage() {
         return (
           <span key={index} className="inline-flex gap-0.5">
             {citationNums.map((num, i) => {
-              // Citation numbers are 1-indexed, array is 0-indexed
               const citationIndex = parseInt(num) - 1;
               const citation = citations[citationIndex];
-              const filename = citation?.document || `Source ${num}`;
-              const page = citation?.page;
-              const chunk = citation?.chunk || "";
-              // Use single line tooltip - browsers don't render \n in title
-              const preview = chunk
-                ? chunk.substring(0, 150).replace(/\s+/g, " ").trim()
-                : "";
-
-              // Build tooltip based on what data is available
-              let tooltip;
-              if (citation) {
-                if (preview) {
-                  tooltip = `📄 ${filename}${page ? ` (p.${page})` : ""} — ${preview}${chunk.length > 150 ? "..." : ""}`;
-                } else {
-                  tooltip = `📄 ${filename}${page ? ` (p.${page})` : ""}`;
-                }
-              } else {
-                tooltip = `Citation ${num} (no data available)`;
-              }
-
               return (
-                <sup
-                  key={i}
-                  className="text-blue-600 font-medium text-xs cursor-help hover:text-blue-800 hover:underline"
-                  title={tooltip}
-                >
-                  [{num}]
-                </sup>
+                <CitationTooltip key={i} num={num} citation={citation} />
               );
             })}
           </span>

--- a/frontend/src/app/playground/page.js
+++ b/frontend/src/app/playground/page.js
@@ -186,7 +186,12 @@ export default function PlaygroundPage() {
       // Join playground room IMMEDIATELY before state updates
       // This prevents race condition where callback arrives before useEffect runs
       const newSessionId = response.data.session_id;
-      if (socket && isConnected && newSessionId && newSessionId !== currentSessionId) {
+      if (
+        socket &&
+        isConnected &&
+        newSessionId &&
+        newSessionId !== currentSessionId
+      ) {
         socket.emit("join_playground", { session_id: newSessionId });
       }
 
@@ -315,9 +320,7 @@ export default function PlaygroundPage() {
             {citationNums.map((num, i) => {
               const citationIndex = parseInt(num) - 1;
               const citation = citations[citationIndex];
-              return (
-                <CitationTooltip key={i} num={num} citation={citation} />
-              );
+              return <CitationTooltip key={i} num={num} citation={citation} />;
             })}
           </span>
         );
@@ -370,7 +373,9 @@ export default function PlaygroundPage() {
                 <div className="space-y-2 text-sm">
                   <div>
                     <span className="text-gray-600">Service:</span>{" "}
-                    <span className="font-medium">{activeService.service_name}</span>
+                    <span className="font-medium">
+                      {activeService.service_name}
+                    </span>
                   </div>
                   <div>
                     <span className="text-gray-600">Status:</span>{" "}
@@ -393,7 +398,9 @@ export default function PlaygroundPage() {
                       <div>
                         <span className="text-gray-600">Knowledge Base:</span>{" "}
                         <span className="font-medium">
-                          {loadingDocs ? "Loading..." : knowledgeBase?.title || "-"}
+                          {loadingDocs
+                            ? "Loading..."
+                            : knowledgeBase?.title || "-"}
                         </span>
                       </div>
                       <div>
@@ -403,13 +410,19 @@ export default function PlaygroundPage() {
                         ) : documents.length > 0 ? (
                           <ul className="mt-1 space-y-0.5">
                             {documents.map((doc) => (
-                              <li key={doc.id} className="text-xs text-gray-500 truncate" title={doc.filename}>
+                              <li
+                                key={doc.id}
+                                className="text-xs text-gray-500 truncate"
+                                title={doc.filename}
+                              >
                                 • {doc.filename}
                               </li>
                             ))}
                           </ul>
                         ) : (
-                          <span className="text-gray-400 ml-1">No documents</span>
+                          <span className="text-gray-400 ml-1">
+                            No documents
+                          </span>
                         )}
                       </div>
                     </>
@@ -456,7 +469,6 @@ export default function PlaygroundPage() {
                 </button>
               </div>
             </div>
-
           </div>
 
           {/* Center Panel - Chat Interface */}


### PR DESCRIPTION
## Summary

- Added hoverable citation tooltips showing document name, page, and content preview
- Display active knowledge base and document list in the playground service panel
- Pass citations from AI callback through WebSocket to frontend for rendering
- Fixed race condition where WebSocket callback could arrive before room join

## Changes

### Frontend (`frontend/src/app/playground/page.js`)
- **Citation formatting**: Parse `[citation:X]` patterns and render as hoverable superscripts `[1]`
- **Tooltip content**: Shows 📄 filename, page number, and first 150 chars of cited chunk
- **KB display**: Added knowledge base name and document list under WebSocket status
- **Race condition fix**: Join playground room immediately after API response, before React state updates
- **Debug logging**: Added console logs to trace citation flow for troubleshooting

### Backend
- **`routers/admin_playground.py`**: Added `active_knowledge_base_id` to active service response
- **`routers/callbacks.py`**: Extract and pass citations to WebSocket emit
- **`services/socketio_service.py`**: Added `citations` parameter to `emit_playground_response`
- **`schemas/callback.py`**: Updated Citation schema to match Akvo RAG format (`document`, `chunk`, `page`)

## Test plan

- [ ] Send a message in playground that triggers AI response with citations
- [ ] Verify citations render as blue superscripts `[1]`, `[2]`, etc.
- [ ] Hover over citation to see tooltip with document info
- [ ] Verify knowledge base name and documents display in service panel
- [ ] Check browser console for citation debug logs
- [ ] Confirm WhatsApp/customer chat still strips citations (no tooltip code there)

## Screenshots

_Pending manual verification_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216705277216206